### PR TITLE
Restructure the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,31 +7,94 @@ This source is not intended to be compilable; rather the intent is for
 it to be kept under source control, so that any changes to public API
 are easy to detect and track.
 
-## Configuration
+## Configuration - Properties
 
 The following properties can be set in the project to affect the
 behaviour:
 
-| Property                            | Description                                                                                                                                                                                        |
-|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ApiReferenceFormat                  | The format to use for the API Reference source.<br/>Supported Values: `C#` (or `cs` or `csharp`) for C#, and `C#-MarkDown` (or variations using `cs`, `csharp` and/or `md`) for MarkDown-with-C#.  |
-| ApiReferenceLibraryPath             | The directories to search for the dependencies of the output assemblies (separated by semicolons).<br/>If not specified, it will use the list of referenced assemblies as determined by the build. |
-| ApiReferenceOutputDir               | The directory where the API Reference source is created.<br/>Defaults to `$(TargetDir)`.                                                                                                           |
-| ApiReferenceOutputExt               | The extension used for the API Reference source.<br/>Defaults to `.cs` when the format is C#, and `.cs.md` when the format is MarkDown-with-C#.                                                    |
-| ApiReferenceOutputPath              | The full path of the API Reference source.<br/>Defaults to `$(ApiReferenceOutputDir)$(TargetName)$(ApiReferenceOutputExt)`.                                                                        |
-| CreateApiReferenceOutputDir         | Determines whether the directory part of `ApiReferenceOutputPath` will be created as part of the processing.<br/>Defaults to `false`.                                                              |
-| GenerateApiReference                | Determines whether API Reference sources will be generated for each assembly.<br/>Defaults to `true`.                                                                                              |
-| MonoRunner                          | The program used to run the generator under Mono.<br/>Defaults to `mono --runtime=v4.0.30319`.                                                                                                     |
-| NetCoreRunner                       | The program used to run the generator under .NET Core.<br/>Defaults to `dotnet`.                                                                                                                   |
-| SkipApiReferenceOutputPathFileWrite | Determines whether the output files are registered in `@(FileWrites)`.<br/>Defaults to `false`.                                                                                                    |
+### ApiReferenceFormat
 
-In addition, the choice of which attributes to consider part of the
-public API is based on two item groups:
+The format to use for the API Reference source.
 
-| Property                     | Description                                                                                                                 |
-|------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| ApiReferenceIncludeAttribute | Attributes to include. If not specified, all attributes are include, unless excluded via `@(ApiReferenceExcludeAttribute)`. |
-| ApiReferenceExcludeAttribute | Attributes to exclude. Applies to attributes included via `@(ApiReferenceIncludeAttribute)`.                                |
+Supported Values: `C#` (or `cs` or `csharp`) for C#, and `C#-MarkDown`
+(or variations using `cs`, `csharp` instead of `C#` and/or `md` instead
+of `MarkDown`) for MarkDown-with-C#.
+
+### ApiReferenceLibraryPath
+
+The directories to search for the dependencies of the output assemblies
+(separated by semicolons).
+
+If not specified, it will use the list of referenced assemblies as
+determined by the build.
+
+### ApiReferenceOutputDir
+
+The directory where the API Reference source is created.
+
+Defaults to `$(TargetDir)`.
+
+### ApiReferenceOutputExt
+
+The extension used for the API Reference source.
+
+Defaults to `.cs` when the format is C#, and `.cs.md` when the format is
+MarkDown-with-C#.
+
+### ApiReferenceOutputPath
+
+The full path of the API Reference source.
+
+Defaults to
+`$(ApiReferenceOutputDir)$(TargetName)$(ApiReferenceOutputExt)`.
+
+Note: when setting this yourself in a project file, you cannot rely on
+any of the other defaulted properties (like `ApiReferenceOutputExt`,
+for example), because that defaulting happens after the project file is
+read. To be able to do that, set it in `Directory.Build.targets`
+([docs][d.b.t]).
+
+### CreateApiReferenceOutputDir
+
+Determines whether the directory part of `ApiReferenceOutputPath` will
+be created as part of the processing.
+
+Defaults to `false`.
+
+### GenerateApiReference
+
+Determines whether API Reference sources will be generated for each
+assembly.
+
+Defaults to `true`.
+
+### MonoRunner
+
+The program used to run the generator under Mono.
+
+Defaults to `mono --runtime=v4.0.30319`.
+
+### NetCoreRunner
+
+The program used to run the generator under .NET Core.
+
+Defaults to `dotnet`.
+
+### SkipApiReferenceOutputPathFileWrite
+
+Determines whether the output files are registered in `@(FileWrites)`.
+
+Defaults to `false`.
+
+## Configuration - Which Attributes to Include
+
+The choice of which attributes to consider part of the public API is
+based on two item groups:
+
+| Property                     | Description                                                                                                                     |
+|------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| ApiReferenceIncludeAttribute | Attributes to include. If not specified, all attributes are included, unless excluded via `@(ApiReferenceExcludeAttribute)`.    |
+| ApiReferenceExcludeAttribute | Attributes to exclude. Applies to attributes included (whether explicitly or implicitly) via `@(ApiReferenceIncludeAttribute)`. |
 
 In both cases, shell wildcards (`?` and `*`) are supported. Names match
 against the full internal name of the attribute type (like
@@ -57,3 +120,5 @@ Package icon created by [DinosoftLabs - FlatIcon][PackageIcon].
 
 [GHReleases]: https://github.com/Zastai/Zastai.Build.APIReference/releases
 [PackageIcon]: https://www.flaticon.com/free-icon/browser_718064
+
+[d.b.t]: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build#directorybuildprops-and-directorybuildtargets


### PR DESCRIPTION
nuget.org renders the README nicely, except that it does not handle any
HTML tags, including `<br/>`. As a result, the multiline table cells do
not render as multiline there, making them less readable.

So the big table has been dropped in favour of separate headings for
each property.

The two item groups used for including/excluding attributes keep a table
for now.

Other changes:
- the description for `ApiReferenceFormat` was made slightly clearer
- for `ApiReferenceOutputPath`, make it clear that in order to refer to
  defaulted properties like `ApiReferenceOutputExt`, it needs to be set
  after that defaulting happens