### PR TITLE
Fix attribute processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,8 @@ based on two item groups:
 | ApiReferenceIncludeAttribute | Attributes to include. If not specified, all attributes are included, unless excluded via `@(ApiReferenceExcludeAttribute)`.    |
 | ApiReferenceExcludeAttribute | Attributes to exclude. Applies to attributes included (whether explicitly or implicitly) via `@(ApiReferenceIncludeAttribute)`. |
 
-In both cases, shell wildcards (`?` and `*`) are supported. Names match
-against the full internal name of the attribute type (like
-``Namespace.GenericTypeName`2/NestedAttribute``).
+In both cases, names match against the full internal name of the
+attribute type (like ``Namespace.GenericTypeName`2/NestedAttribute``).
 Attributes handled as part of syntax generation (like
 `System.ParamArrayAttribute` and
 `System.Runtime.CompilerServices.ExtensionAttribute`) are never

--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -273,6 +273,64 @@ internal class CSharpFormatter : CodeFormatter {
     return sb.ToString();
   }
 
+  protected override bool IsHandledBySyntax(ICustomAttribute ca) {
+    var at = ca.AttributeType;
+    if (at is null) {
+      return false;
+    }
+    switch (at.Namespace) {
+      case "System":
+        switch (at.Name) {
+          case "ParamArrayAttribute":
+            // Mapped to "params" keyword on parameters.
+            return true;
+        }
+        break;
+      case "System.Runtime.CompilerServices":
+        switch (at.Name) {
+          case "AsyncStateMachineAttribute":
+          case "CompilerGeneratedAttribute":
+          case "IteratorStateMachineAttribute":
+          case "ReferenceAssemblyAttribute":
+            // Guaranteed not to be relevant to the API.
+            return true;
+          case "ExtensionAttribute":
+            // Not relevant at assembly/type level (just flags presence of extension methods).
+            // Mapped to "this" keyword on parameters.
+            return true;
+          case "DynamicAttribute":
+            // Mapped to "dynamic" keyword.
+            return true;
+          case "IsByRefLikeAttribute":
+            // Mapped to "ref" keyword.
+            return true;
+          case "IsReadOnlyAttribute":
+            // Mapped to "readonly" keyword.
+            return true;
+          case "IsUnmanagedAttribute":
+            // Mapped to "unmanaged" keyword.
+            return true;
+          case "NativeIntegerAttribute":
+            // Mapped to "nint"/"nuint" keywords.
+            return true;
+          case "NonNullTypesAttribute":
+          case "NullableAttribute":
+          case "NullableContextAttribute":
+          case "NullablePublicOnlyAttribute":
+            // TODO: These should be interpreted in order to add '?' after a type name where applicable
+            return true;
+          case "PreserveBaseOverridesAttribute":
+            // Used to detect covariant return types.
+            return true;
+          case "TupleElementNamesAttribute":
+            // Names extracted for use in tuple syntax.
+            return true;
+        }
+        break;
+    }
+    return false;
+  }
+
   protected override string LineComment(string comment) => $"// {comment}".TrimEnd();
 
   protected override string Literal(bool value) => value ? "true" : "false";

--- a/Zastai.Build.ApiReference/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.cs
@@ -430,7 +430,14 @@ internal abstract class CodeFormatter {
 
   protected abstract IEnumerable<string?> Property(PropertyDefinition pd, int indent);
 
+  protected abstract bool IsHandledBySyntax(ICustomAttribute ca);
+
   protected bool Retain(ICustomAttribute ca) {
+    // Attributes handled by syntax (like [Extension] and [ParamArray] for C#) are never retained.
+    if (this.IsHandledBySyntax(ca)) {
+      return false;
+    }
+    // For everything else, use the configured inclusion/exclusion processing
     var name = ca.AttributeType.FullName;
     if (this._attributesToInclude.Count > 0) {
       if (!this._attributesToInclude.Any(pattern => name.Matches(pattern))) {

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
@@ -4,15 +4,31 @@
   <ItemGroup>
 
     <!-- Attributes to include in the API reference.
-       - Shell wildcards (?, *) are supported.
        - If this item group is empty, all attributes are included unless further excluded via @(ApiReferenceExcludeAttribute). -->
     <!-- <ApiReferenceIncludeAttribute Include="*" /> -->
 
     <!-- Attributes to exclude from the API reference; applied to attributes included via @(ApiReferenceIncludeAttribute).
-       - Shell wildcards are supported.
        - If this item group is empty, all attributes are included. -->
     <ApiReferenceExcludeAttribute Include="__DynamicallyInvokableAttribute" />
-    <ApiReferenceExcludeAttribute Include="System.Reflection.Assembly*Attribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyAlgorithmIdAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyCompanyAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyConfigurationAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyCopyrightAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyCultureAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyDefaultAliasAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyDelaySignAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyDescriptionAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyFileVersionAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyFlagsAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyKeyFileAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyKeyNameAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyMetadataAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyProductAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblySignatureKeyAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyTitleAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyTrademarkAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyVersionAttribute" />
 
   </ItemGroup>
 

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
@@ -84,13 +84,13 @@
     <!-- Attributes to Include: Remove Duplicates and Pass. -->
     <ItemGroup>
       <_ApiReferenceIncludeAttributes Include="%(APIReferenceIncludeAttribute.Identity)" />
-      <_ApiReferenceCommandLineOptions Include="-ia &quot;$(_ApiReferenceIncludeAttributes)&quot;" />
+      <_ApiReferenceCommandLineOptions Include="-ia &quot;%(_ApiReferenceIncludeAttributes.Identity)&quot;" />
     </ItemGroup>
 
     <!-- Attributes to Exclude: Remove Duplicates and Pass. -->
     <ItemGroup>
       <_ApiReferenceExcludeAttributes Include="%(APIReferenceExcludeAttribute.Identity)" />
-      <_ApiReferenceCommandLineOptions Include="-ea &quot;$(_ApiReferenceExcludeAttributes)&quot;" />
+      <_ApiReferenceCommandLineOptions Include="-ea &quot;%(_ApiReferenceExcludeAttributes.Identity)&quot;" />
     </ItemGroup>
 
     <!-- Reference Path Configured: Use. -->


### PR DESCRIPTION
* The item groups used to set up include/exclude lists of attributes do not reliably support wildcards (those often get resolved against the filesystem), so the documentation no longer says wildcards are supported, and the list of default excludes has been expanded.
* The logic used to map the include/exclude patterns to command line parameters was wrong and has been corrected.
* The documentation claimed that "technical" attributes (like `[System.ParamArrayAttribute]`) were never retained -- but they were. Now they really aren't.