### PR TITLE
Implement Nullable Reference Types

### DIFF
--- a/Zastai.Build.ApiReference/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.cs
@@ -94,7 +94,7 @@ internal abstract class CodeFormatter {
 
   protected abstract string EnumField(FieldDefinition fd, int indent);
 
-  protected virtual string EnumValue(TypeDefinition enumType, string name) => $"{this.TypeName(enumType)}.{name}";
+  protected abstract string EnumValue(TypeDefinition enumType, string name);
 
   protected abstract string Event(EventDefinition ed, int indent);
 
@@ -511,8 +511,6 @@ internal abstract class CodeFormatter {
   protected virtual IEnumerable<string?> TypeHeader(TypeDefinition td) {
     yield return null;
   }
-
-  protected abstract string TypeName(TypeReference tr, ICustomAttributeProvider? context = null);
 
   protected abstract string TypeOf(TypeReference tr);
 

--- a/Zastai.Build.ApiReference/Nullability.cs
+++ b/Zastai.Build.ApiReference/Nullability.cs
@@ -1,0 +1,11 @@
+namespace Zastai.Build.ApiReference;
+
+internal enum Nullability {
+
+  Oblivious = 0,
+
+  NotNull = 1,
+
+  Nullable = 2,
+
+}


### PR DESCRIPTION
The `[Nullable]` and `[NullableContext]` attributes should now be correctly interpreted to mark nullable reference types correctly.