### PR TITLE
Switch to GH Actions for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,16 +33,16 @@ jobs:
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: MSBuild Log Files
+        name: MSBuild Log Files (${{matrix.configuration}})
         path: msbuild.*.binlog
     - name: Store NuGet Package
       uses: actions/upload-artifact@v3
       with:
-        name: NuGet Package
+        name: NuGet Package (${{matrix.configuration}})
         path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: Show current ref
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/pull/')
       run: 'echo github.ref: ${{github.ref}}'
     - name: Publish NuGet Package
-      if: startsWith(github.ref, 'refs/tags/v')
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
       run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
       # FIXME: Maybe only do this on a tag?
       with:
         name: NuGet Package (.NET ${{ matrix.dotnet-version }})
-        path: **/bin/Release/*.nupkg
+        path: ./**/bin/Release/*.nupkg
 # TODO: If it's a tag build, publish the NuGet package to GitHub Packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
     - name: Create global.json
-        run: echo '{ "sdk": { "version": "${{ steps.dotnet-setup.outputs.dotnet-version}}" } }' > ./global.json
+      run: echo '{ "sdk": { "version": "${{ steps.dotnet-setup.outputs.dotnet-version}}" } }' > ./global.json
     - name: Run Build Script
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration Release
     - name: Store Log for Failed Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         dotnet-version: ['6.0.x', '7.0.x']
@@ -21,7 +21,7 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
     - name: Run Build Script
-      run: .\build-package.ps1 -WithBinLog -Configuration Release
+      run: pwsh ./build-package.ps1 -WithBinLog -Configuration Release
     - name: Store Log for Failed Build
       uses: actions/upload-artifact@v3
       if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,12 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    env:
+      dotnet-version: 7.0.x
     strategy:
       matrix:
         configuration: ['Debug', 'Release']
-    env:
-      dotnet-version: 6.0.x
 
     steps:
     - uses: actions/checkout@v3
@@ -27,18 +26,18 @@ jobs:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
       run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
-    - name: "Run Build Script (Configuration: ${{matrix.configuration}})"
+    - name: Run build script (${{matrix.configuration}} configuration)
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
-    - name: Store Logs for Failed Build
+    - name: "Artifact: MSBuild Logs"
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: MSBuild Log Files (${{matrix.configuration}})
+        name: MSBuild Logs (${{matrix.configuration}})
         path: msbuild.*.binlog
-    - name: Store NuGet Package
+    - name: "Artifact: NuGet packages"
       uses: actions/upload-artifact@v3
       with:
-        name: NuGet Package (${{matrix.configuration}})
+        name: NuGet Packages (${{matrix.configuration}})
         path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: Show current ref
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/pull/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: ['6.0.x', '7.0.x' ]
+        dotnet-version: ['6.0.x', '7.0.x']
 
     steps:
     - uses: actions/checkout@v3
@@ -33,5 +33,5 @@ jobs:
       # FIXME: Maybe only do this on a tag?
       with:
         name: NuGet Package (.NET ${{ matrix.dotnet-version }})
-        path: *\bin\Release\*.nupkg
-    # TODO: If it's a tag, publish to GitHub Packages automatically.
+        path: **/bin/Release/*.nupkg
+# TODO: If it's a tag build, publish the NuGet package to GitHub Packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET ${{ matrix.dotnet-version }}
+    - name: Set Up .NET ${{ matrix.dotnet-version }}
       uses: actions/setup-dotnet@v3
+      id: dotnet-setup
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
+    - name: Create global.json
+        run: echo '{ "sdk": { "version": "${{ steps.dotnet-setup.outputs.dotnet-version}}" } }' > ./global.json
     - name: Run Build Script
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration Release
     - name: Store Log for Failed Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,7 @@ jobs:
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json
-      run:
-        echo '{ "sdk": { "version": "${{steps.setup.outputs.dotnet-version}}" } }' > ./global.json
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
     - name: Run Build Script
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration Release
     - name: Store Log for Failed Build
@@ -40,8 +39,7 @@ jobs:
         name: NuGet Package (.NET SDK ${{steps.setup.outputs.dotnet-version}})
         path: ./**/bin/Release/*.nupkg
     - name: Show current ref
-      run:
-        echo github.ref: ${{github.ref}}
+      run: 'echo github.ref: ${{github.ref}}'
     - name: Publish NuGet Package
       if: startsWith(github.ref, 'refs/tags/v')
       run: dotnet nuget push */bin/Release/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,25 +16,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set Up .NET ${{ matrix.dotnet-version }}
+    - name: Set Up .NET ${{matrix.dotnet-version}}
       uses: actions/setup-dotnet@v3
-      id: dotnet-setup
+      id: setup
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}
+        dotnet-version: ${{matrix.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json
-      run: echo '{ "sdk": { "version": "${{ steps.dotnet-setup.outputs.dotnet-version}}" } }' > ./global.json
+      run: echo '{"sdk":{"version": "${{ steps.setup.outputs.dotnet-version }}"}}' > ./global.json
     - name: Run Build Script
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration Release
     - name: Store Log for Failed Build
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: MSBuild Log File (.NET ${{ matrix.dotnet-version }})
+        name: MSBuild Log File (.NET SDK ${{steps.setup.outputs.dotnet-version}})
         path: msbuild.binlog
     - name: Store NuGet Package
       uses: actions/upload-artifact@v3
-      # FIXME: Maybe only do this on a tag?
       with:
-        name: NuGet Package (.NET ${{ matrix.dotnet-version }})
+        name: NuGet Package (.NET SDK ${{steps.setup.outputs.dotnet-version}})
         path: ./**/bin/Release/*.nupkg
-# TODO: If it's a tag build, publish the NuGet package to GitHub Packages
+    - name: Show current ref
+      run: echo github.ref: ${{github.ref}}
+    - name: Publish NuGet Package
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: dotnet nuget push */bin/Release/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}})
       run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
-    - name: Run Build Script (Configuration: ${{matrix.configuration}})
+    - name: "Run Build Script (Configuration: ${{matrix.configuration}})"
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
     - name: Store Logs for Failed Build
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
         configuration: ['Debug', 'Release']
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Check out the project
+      uses: actions/checkout@v3
     - name: Set up .NET ${{env.dotnet-version}}
       uses: actions/setup-dotnet@v3
       id: setup
@@ -26,7 +27,7 @@ jobs:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
       run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
-    - name: Run build script (${{matrix.configuration}} configuration)
+    - name: Run build script (${{matrix.configuration}})
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
     - name: "Artifact: MSBuild Logs"
       uses: actions/upload-artifact@v3
@@ -34,14 +35,11 @@ jobs:
       with:
         name: MSBuild Logs (${{matrix.configuration}})
         path: msbuild.*.binlog
-    - name: "Artifact: NuGet packages"
+    - name: "Artifact: NuGet Packages"
       uses: actions/upload-artifact@v3
       with:
         name: NuGet Packages (${{matrix.configuration}})
         path: "**/bin/${{matrix.configuration}}/*.nupkg"
-    - name: Show current ref
-      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/pull/')
-      run: 'echo github.ref: ${{github.ref}}'
-    - name: Publish NuGet Package
+    - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
       run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        dotnet-version: ['6.0.x', '7.0.x' ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET ${{ matrix.dotnet-version }}
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+    - name: Run Build Script
+      run: .\build-package.ps1 -WithBinLog -Configuration Release
+    - name: Store Log for Failed Build
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Log File (.NET ${{ matrix.dotnet-version }})
+        path: msbuild.binlog
+    - name: Store NuGet Package
+      uses: actions/upload-artifact@v3
+      # FIXME: Maybe only do this on a tag?
+      with:
+        name: NuGet Package (.NET ${{ matrix.dotnet-version }})
+        path: *\bin\Release\*.nupkg
+    # TODO: If it's a tag, publish to GitHub Packages automatically.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,33 +12,36 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['6.0.x', '7.0.x']
+        configuration: ['Debug', 'Release']
+    env:
+      dotnet-version: 7.0.x
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set Up .NET ${{matrix.dotnet-version}}
+    - name: Set up .NET ${{env.dotnet-version}}
       uses: actions/setup-dotnet@v3
       id: setup
       with:
-        dotnet-version: ${{matrix.dotnet-version}}
+        dotnet-version: ${{env.dotnet-version}}
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    - name: Create global.json
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}})
       run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
-    - name: Run Build Script
-      run: pwsh ./build-package.ps1 -WithBinLog -Configuration Release
-    - name: Store Log for Failed Build
+    - name: Run Build Script (Configuration: ${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: Store Logs for Failed Build
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: MSBuild Log File (.NET SDK ${{steps.setup.outputs.dotnet-version}})
-        path: msbuild.binlog
+        name: MSBuild Log Files
+        path: msbuild.*.binlog
     - name: Store NuGet Package
       uses: actions/upload-artifact@v3
       with:
-        name: NuGet Package (.NET SDK ${{steps.setup.outputs.dotnet-version}})
+        name: NuGet Package
         path: ./**/bin/Release/*.nupkg
     - name: Show current ref
+      if: matrix.configuration == 'Release'
       run: 'echo github.ref: ${{github.ref}}'
     - name: Publish NuGet Package
       if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json
-      run: echo '{"sdk":{"version": "${{ steps.setup.outputs.dotnet-version }}"}}' > ./global.json
+      run:
+        echo '{ "sdk": { "version": "${{steps.setup.outputs.dotnet-version}}" } }' > ./global.json
     - name: Run Build Script
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration Release
     - name: Store Log for Failed Build
@@ -39,7 +40,8 @@ jobs:
         name: NuGet Package (.NET SDK ${{steps.setup.outputs.dotnet-version}})
         path: ./**/bin/Release/*.nupkg
     - name: Show current ref
-      run: echo github.ref: ${{github.ref}}
+      run:
+        echo github.ref: ${{github.ref}}
     - name: Publish NuGet Package
       if: startsWith(github.ref, 'refs/tags/v')
       run: dotnet nuget push */bin/Release/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         configuration: ['Debug', 'Release']
     env:
-      dotnet-version: 7.0.x
+      dotnet-version: 6.0.x
 
     steps:
     - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
         dotnet-version: ${{env.dotnet-version}}
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}})
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
       run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
     - name: "Run Build Script (Configuration: ${{matrix.configuration}})"
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
@@ -39,10 +39,10 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: NuGet Package
-        path: ./**/bin/Release/*.nupkg
+        path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: Show current ref
-      if: matrix.configuration == 'Release'
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/pull/')
       run: 'echo github.ref: ${{github.ref}}'
     - name: Publish NuGet Package
       if: startsWith(github.ref, 'refs/tags/v')
-      run: dotnet nuget push */bin/Release/*.nupkg
+      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg"

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ These are available [on GitHub][GHReleases].
 
 Package icon created by [DinosoftLabs - FlatIcon][PackageIcon].
 
-[CI-S]: https://img.shields.io/appveyor/build/zastai/zastai-build-apireference
-[CI-L]: https://ci.appveyor.com/project/Zastai/zastai-build-apireference
+[CI-S]: https://github.com/Zastai/Zastai.Build.APIReference/actions/workflows/build.yml/badge.svg
+[CI-L]: https://github.com/Zastai/Zastai.Build.APIReference/actions/workflows/build.yml
 
 [NuGet-S]: https://img.shields.io/nuget/v/Zastai.Build.ApiReference
 [NuGet-L]: https://www.nuget.org/packages/Zastai.Build.ApiReference

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - pwsh: .\build-package.ps1 -Configuration Debug

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -28,7 +28,11 @@ function Complete-BuildStep {
 }
 
 Write-Host 'Cleaning up existing build output...'
-Remove-Item -Recurse -Force */bin/$Configuration, */obj/$Configuration
+Remove-Item -Force -Recurse */bin/$Configuration, */obj/$Configuration
+Remove-Item -Force msbuild.*.binlog
+if (Test-Path msbuild.binlog) {
+  Remove-Item -Force msbuild.binlog
+}
 Write-Host ''
 
 Write-Host "Running package restore..."


### PR DESCRIPTION
This replaces the AppVeyor-based CI with a GitHub workflow.

The build script is tweaked slightly to clean up MSBuild log files at the start.