### PR TITLE
Avoid considering `void` as nullable

### DIFF
--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -1122,13 +1122,14 @@ internal class CSharpFormatter : CodeFormatter {
       }
     }
     // A nullability slot is used for every reference type and every generic value type.
+    // Special Case: System.Void is not considered to be a value type, but also does not participate in nullability.
     if (tr.IsValueType) {
       // Assumption: both apply
       if (tr.IsGenericInstance || tr.HasGenericParameters) {
         ++tnc.NullableIndex;
       }
     }
-    else {
+    else if (!tr.IsVoid()) {
       nullability = tnc.Main?.GetNullability(tnc.Method, tnc.Type, tnc.NullableIndex++);
     }
     // Check for System.Nullable<T> and make it T?

--- a/Zastai.Build.ApiReference/CecilUtils.cs
+++ b/Zastai.Build.ApiReference/CecilUtils.cs
@@ -222,6 +222,8 @@ internal static class CecilUtils {
     => gp is not null && gp.HasCustomAttributes &&
        gp.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "IsUnmanagedAttribute"));
 
+  public static bool IsVoid(this TypeReference tr) => tr == tr.Module.TypeSystem.Void;
+
   public static string NonGenericName(this TypeReference tr) {
     var name = tr.Name;
     var backTick = name.IndexOf('`');


### PR DESCRIPTION
Cecil does not consider `void` to be a value type, so it was getting processed as a reference type, including nullability processing.

Fixes #21.