### PR TITLE
Fix NuGet package publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,5 @@ jobs:
         name: NuGet Packages (${{matrix.configuration}})
         path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: Publish (NuGet - GitHub Packages)
-      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      if: matrix.configuration == 'Release' # && startsWith(github.ref, 'refs/tags/v')
       run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
         name: NuGet Packages (${{matrix.configuration}})
         path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: Publish (NuGet - GitHub Packages)
-      if: matrix.configuration == 'Release' # && startsWith(github.ref, 'refs/tags/v')
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
       run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
-#    - name: Publish (NuGet - nuget.org)
-#      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-#      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,4 +42,7 @@ jobs:
         path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' # && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg"
+      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+#    - name: Publish (NuGet - nuget.org)
+#      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+#      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"


### PR DESCRIPTION
This fixes the `nuget push` command line and adds a step to publish to nuget.org too