### PR TITLE
Trigger the build workflow on tag pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,13 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - 'main'
 
 jobs:
   build:


### PR DESCRIPTION
While the package publishing was checking for a tag ref, the workflow was only triggered by PRs or pushes to main.
It should now also trigger on pushes to version tags (vN.N.N).