### PR TITLE
Update the build targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      dotnet-version: 7.0.x
+      dotnet-version: 8.0.x
     strategy:
       matrix:
         configuration: ['Debug', 'Release']

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <Nullable>enable</Nullable>

--- a/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
+++ b/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The sandbox project now targets the latest .NET version (`net8.0`).

The main project switches from the now out of support `netcoreapp3.1` to `net6.0` as the target (for use with `dotnet.exe`) alongside `net472` (for use with `msbuild.exe`).