### PR TITLE
Fix/Improve method sort order

### DIFF
--- a/Zastai.Build.ApiReference.sln.DotSettings
+++ b/Zastai.Build.ApiReference.sln.DotSettings
@@ -65,6 +65,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=comparers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=modopt/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nint/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=nuint/@EntryIndexedValue">True</s:Boolean>

--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -1043,8 +1043,8 @@ internal class CSharpFormatter : CodeFormatter {
     return sb.ToString();
   }
 
-  protected virtual string TypeName(TypeReference tr, ICustomAttributeProvider? context = null,
-                                    MethodDefinition? methodContext = null, TypeDefinition? typeContext = null) {
+  protected override string TypeName(TypeReference tr, ICustomAttributeProvider? context = null,
+                                     MethodDefinition? methodContext = null, TypeDefinition? typeContext = null) {
     var prefix = "";
     // ref X can only occur on outer types; can't have an array of `ref int` or a `Func<ref int>`, so handle that here
     if (tr is ByReferenceType brt) { // => ref T

--- a/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
@@ -1,0 +1,83 @@
+﻿ namespace Zastai.Build.ApiReference;
+
+internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
+
+  public int Compare(MethodDefinition? x, MethodDefinition? y) {
+    if (object.ReferenceEquals(x, y)) {
+      return 0;
+    }
+    if (x is null) {
+      return -1;
+    }
+    if (y is null) {
+      return +1;
+    }
+    // First level: the method name
+    // FIXME: Or should this use the invariant culture?
+    var cmp = string.Compare(x.Name, y.Name, StringComparison.Ordinal);
+    if (cmp != 0) {
+      return cmp;
+    }
+    // Second level: generic types
+    if (x.HasGenericParameters && y.HasGenericParameters) {
+      using var walker1 = x.GenericParameters.GetEnumerator();
+      using var walker2 = y.GenericParameters.GetEnumerator();
+      while (walker1.MoveNext()) {
+        if (!walker2.MoveNext()) {
+          return +1;
+        }
+        // Assumption: the full name of the generic parameter is suitable as comparison/sort form.
+        // FIXME: Or should this also use the stringification implemented by the formatter?
+        var name1 = walker1.Current?.FullName;
+        var name2 = walker2.Current?.FullName;
+        // FIXME: Or should this use the invariant culture?
+        cmp = string.Compare(name1, name2, StringComparison.Ordinal);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+      if (walker2.MoveNext()) {
+        return -1;
+      }
+    }
+    else if (x.HasGenericParameters) {
+      return +1;
+    }
+    else if (y.HasGenericParameters) {
+      return -1;
+    }
+    // Level 3: parameter types
+    if (x.HasParameters && y.HasParameters) {
+      using var walker1 = x.Parameters.GetEnumerator();
+      using var walker2 = y.Parameters.GetEnumerator();
+      while (walker1.MoveNext()) {
+        if (!walker2.MoveNext()) {
+          return +1;
+        }
+        // This uses the formatter-specific idea of a type's string form. That also means that Int16 sorts after Int32 for the C#
+        // formatter (because "short" follows "int").
+        var type1 = walker1.Current?.ParameterType;
+        var name1 = type1 is null ? null : this.TypeName(type1, x);
+        var type2 = walker2.Current?.ParameterType;
+        var name2 = type2 is null ? null : this.TypeName(type2, y);
+        // FIXME: Or should this use the invariant culture?
+        cmp = string.Compare(name1, name2, StringComparison.Ordinal);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+      if (walker2.MoveNext()) {
+        return -1;
+      }
+    }
+    else if (x.HasParameters) {
+      return +1;
+    }
+    else if (y.HasParameters) {
+      return -1;
+    }
+    // FIXME: Are there other things to compare?
+    return 0;
+  }
+
+}

--- a/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
@@ -12,7 +12,11 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
     if (y is null) {
       return +1;
     }
-    // Level 1: the method name
+    // Level 0: Put the constructors at the top.
+    if (x.IsRuntimeSpecialName != y.IsRuntimeSpecialName) {
+      return x.IsRuntimeSpecialName ? -1 : +1;
+    }
+    // Level 1: The method name.
     // FIXME: Or should this use the invariant culture?
     {
       var name1 = this.MethodName(x);
@@ -22,7 +26,7 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
         return cmp;
       }
     }
-    // Level 2: generic types
+    // Level 2: Generic types.
     if (x.HasGenericParameters && y.HasGenericParameters) {
       using var walker1 = x.GenericParameters.GetEnumerator();
       using var walker2 = y.GenericParameters.GetEnumerator();
@@ -50,7 +54,7 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
     else if (y.HasGenericParameters) {
       return -1;
     }
-    // Level Three: parameter types
+    // Level Three: Parameter types.
     if (x.HasParameters && y.HasParameters) {
       using var walker1 = x.Parameters.GetEnumerator();
       using var walker2 = y.Parameters.GetEnumerator();

--- a/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
@@ -12,13 +12,17 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
     if (y is null) {
       return +1;
     }
-    // First level: the method name
+    // Level 1: the method name
     // FIXME: Or should this use the invariant culture?
-    var cmp = string.Compare(x.Name, y.Name, StringComparison.Ordinal);
-    if (cmp != 0) {
-      return cmp;
+    {
+      var name1 = this.MethodName(x);
+      var name2 = this.MethodName(y);
+      var cmp = string.Compare(name1, name2, StringComparison.Ordinal);
+      if (cmp != 0) {
+        return cmp;
+      }
     }
-    // Second level: generic types
+    // Level 2: generic types
     if (x.HasGenericParameters && y.HasGenericParameters) {
       using var walker1 = x.GenericParameters.GetEnumerator();
       using var walker2 = y.GenericParameters.GetEnumerator();
@@ -31,7 +35,7 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
         var name1 = walker1.Current?.FullName;
         var name2 = walker2.Current?.FullName;
         // FIXME: Or should this use the invariant culture?
-        cmp = string.Compare(name1, name2, StringComparison.Ordinal);
+        var cmp = string.Compare(name1, name2, StringComparison.Ordinal);
         if (cmp != 0) {
           return cmp;
         }
@@ -46,7 +50,7 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
     else if (y.HasGenericParameters) {
       return -1;
     }
-    // Level 3: parameter types
+    // Level Three: parameter types
     if (x.HasParameters && y.HasParameters) {
       using var walker1 = x.Parameters.GetEnumerator();
       using var walker2 = y.Parameters.GetEnumerator();
@@ -61,7 +65,7 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
         var type2 = walker2.Current?.ParameterType;
         var name2 = type2 is null ? null : this.TypeName(type2, y);
         // FIXME: Or should this use the invariant culture?
-        cmp = string.Compare(name1, name2, StringComparison.Ordinal);
+        var cmp = string.Compare(name1, name2, StringComparison.Ordinal);
         if (cmp != 0) {
           return cmp;
         }

--- a/Zastai.Build.ApiReference/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.cs
@@ -281,6 +281,8 @@ internal abstract partial class CodeFormatter {
 
   protected abstract IEnumerable<string?> Method(MethodDefinition md, int indent);
 
+  protected abstract string MethodName(MethodDefinition md);
+
   protected IEnumerable<string?> Methods(TypeDefinition td, int indent) {
     if (!td.HasMethods) {
       yield break;

--- a/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
+++ b/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
@@ -17,7 +17,7 @@
     <PackageReadMeFile>README.md</PackageReadMeFile>
     <PackageTags>C# API Reference</PackageTags>
     <Title>API Reference Generator</Title>
-    <Version>1.1.3-pre</Version>
+    <Version>2.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
With .NET 8, the sorting applied for methods results in a different order than on older targets.
Instead of a `SortedDictionary` with a custom-created sort key, we now use a `SortedSet` and provide an implementation of `IComparer` for method definitions. This allows finer control over the comparison.

Note that this now also causes the sorting for parameter types to be based on their text form in the selected formatter. This means that `System.Int16` (formatted as `short`) now sorts after `System.Int32` (formatted as `int`).

The same approach should probably be applied to all other places where we currently use `SortedDictionary`.

Fixes #39.