### PR TITLE
Add initial `NumericIntPtr` support

### DIFF
--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -1179,7 +1179,7 @@ internal class CSharpFormatter : CodeFormatter {
       else if (tr == ts.Int64) {
         sb.Append("long");
       }
-      else if (tr == ts.IntPtr && tnc.Main.IsNativeInteger(tnc.IntegerIndex++)) {
+      else if (tr == ts.IntPtr && (this.HasRuntimeFeature("NumericIntPtr") || tnc.Main.IsNativeInteger(tnc.IntegerIndex++))) {
         sb.Append("nint");
       }
       else if (tr == ts.SByte) {
@@ -1203,7 +1203,7 @@ internal class CSharpFormatter : CodeFormatter {
       else if (tr == ts.UInt64) {
         sb.Append("ulong");
       }
-      else if (tr == ts.UIntPtr && tnc.Main.IsNativeInteger(tnc.IntegerIndex++)) {
+      else if (tr == ts.UIntPtr && (this.HasRuntimeFeature("NumericIntPtr") || tnc.Main.IsNativeInteger(tnc.IntegerIndex++))) {
         sb.Append("nuint");
       }
       else if (tr == ts.Void) {

--- a/Zastai.Build.ApiReference/CecilUtils.cs
+++ b/Zastai.Build.ApiReference/CecilUtils.cs
@@ -90,6 +90,22 @@ internal static class CecilUtils {
     return null;
   }
 
+  // FIXME: IReadOnlySet would be better, but is not available on .NET Framework.
+  public static ISet<string> GetRuntimeFeatures(this AssemblyDefinition ad) {
+    var coreLib = ad.MainModule.TypeSystem.CoreLibrary;
+    // FIXME: What this _should_ do is look up System.Runtime.CompilerServices.RuntimeFeature (in the context of coreLib), and
+    //        enumerate all its fields, returning a set containing the names of any that are string constants.
+    //        However, I have not been able to get that initial type lookup to work, and we currently only care about numeric IntPtr
+    //        support, so we just check for .NET 7 or later.
+    if (coreLib is AssemblyNameReference { Name: "System.Runtime" } anr && anr.Version >= Version.Parse("7.0")) {
+      return new HashSet<string> {
+        "NumericIntPtr"
+      };
+    }
+    // FIXME: When we drop .NET Framework support, this could be ImmutableHashSet<string>.Empty (not worth the extra dependency now)
+    return new HashSet<string>();
+  }
+
   public static string?[]? GetTupleElementNames(this ICustomAttributeProvider? cap) {
     if (cap is not null && cap.HasCustomAttributes) {
       foreach (var ca in cap.CustomAttributes) {


### PR DESCRIPTION
This handles the fact that .NET 7 and later no longer add `[NativeIntegerAttribute]` to `[U]IntPtr` references that should be considered `n[u]int`.

Currently this uses a version check; that should be changed at some point to check for the actual runtime feature, but it seems like doing that with Cecil is not easy (it wants to resolve things to the active runtime, not the runtime referenced by the assembly being processed).

Fixes #41.