### PR TITLE
Add more excluded attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,27 @@ attribute type (like ``Namespace.GenericTypeName`2/NestedAttribute``).
 Attributes handled as part of syntax generation (like
 `System.ParamArrayAttribute` and
 `System.Runtime.CompilerServices.ExtensionAttribute`) are never
-included.
+included. Note that wildcards are not supported (MSBuild would match
+those against the file system).
+
+`ApiReferenceExcludeAttribute` has a number of attributes preloaded; you
+can list these out by running the
+`ListAttributesExcludedFromApiReference` target.
+
+You can also use the `Remove` option of the `ItemGroup` to remove some
+or all of them if you would prefer to retain them; this option _does_
+allow wildcards (they are matched against existing items).
+
+For example,
+
+```xml
+  <ItemGroup>
+    <ApiReferenceExcludeAttribute Remove="System.Reflection.Assembly*Attribute" />
+  </ItemGroup>
+```
+
+will re-enable all the assembly metadata attributes (like
+`[AssemblyProduct]` and `[AssemblyCopyright]`).
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,14 @@ included. Note that wildcards are not supported (MSBuild would match
 those against the file system).
 
 `ApiReferenceExcludeAttribute` has a number of attributes preloaded; you
-can list these out by running the
-`ListAttributesExcludedFromApiReference` target.
+can list these out using something like this:
+
+```xml
+  <Target Name="ListAttributesExcludedFromApiReference">
+    <Message Importance="high" Text="The following attributes are configured to be excluded from the generated API reference:" />
+    <Message Importance="high" Text="- %(ApiReferenceExcludeAttribute.Identity)" />
+  </Target>
+```
 
 You can also use the `Remove` option of the `ItemGroup` to remove some
 or all of them if you would prefer to retain them; this option _does_

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
@@ -1,16 +1,24 @@
 <Project>
 
   <!-- Configuration Defaults; can be modified in the project. -->
+
+  <!-- Attributes to include in the API reference.
+     - If this item group is empty, all attributes are included unless further excluded via @(ApiReferenceExcludeAttribute). -->
   <ItemGroup>
+    <!-- <ApiReferenceIncludeAttribute Include="..." /> -->
 
-    <!-- Attributes to include in the API reference.
-       - If this item group is empty, all attributes are included unless further excluded via @(ApiReferenceExcludeAttribute). -->
-    <!-- <ApiReferenceIncludeAttribute Include="*" /> -->
+    <!-- Empty by default (i.e. all attributes are included). -->
 
-    <!-- Attributes to exclude from the API reference; applied to attributes included via @(ApiReferenceIncludeAttribute).
-       - If this item group is empty, all attributes are included. -->
+  </ItemGroup>
+
+  <!-- Attributes to exclude from the API reference; applied to attributes included via @(ApiReferenceIncludeAttribute).
+     - If this item group is empty, all attributes are included. -->
+  <ItemGroup>
+    <!-- <ApiReferenceExcludeAttribute Include="..." /> -->
+
     <ApiReferenceExcludeAttribute Include="__DynamicallyInvokableAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Diagnostics.DebuggableAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyAlgorithmIdAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyCompanyAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyConfigurationAttribute" />
@@ -31,6 +39,9 @@
     <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyTrademarkAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyVersionAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Resources.NeutralResourcesLanguageAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.CompilationRelaxationsAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute" />
 
   </ItemGroup>
 

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
@@ -124,4 +124,9 @@
 
   </Target>
 
+  <Target Name="ListAttributesExcludedFromApiReference">
+    <Message Importance="high" Text="The following attributes are configured to be excluded from the generated API reference:" />
+    <Message Importance="high" Text="- %(ApiReferenceExcludeAttribute.Identity)" />
+  </Target>
+
 </Project>

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
@@ -124,9 +124,4 @@
 
   </Target>
 
-  <Target Name="ListAttributesExcludedFromApiReference">
-    <Message Importance="high" Text="The following attributes are configured to be excluded from the generated API reference:" />
-    <Message Importance="high" Text="- %(ApiReferenceExcludeAttribute.Identity)" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
They are:
- `System.Diagnostics.DebuggableAttribute`
- `System.Runtime.CompilerServices.CompilationRelaxationsAttribute`
- `System.Runtime.CompilerServices.RuntimeCompatibilityAttribute`
- `System.Runtime.Versioning.RequiresPreviewFeaturesAttribute`

This also extends the documentation for attribute in/exclusion; It now mentions that wildcards are not supported, and that the exclusion list comes preloaded (with a newly-added target provided to list them).

Fixes #45.