### PR TITLE
Improve `ref struct` and `scoped ref` support

### DIFF
--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -340,6 +340,16 @@ internal class CSharpFormatter : CodeFormatter {
           case "ParamArrayAttribute":
             // Mapped to "params" keyword on parameters.
             return true;
+          case "ObsoleteAttribute":
+            // A few very specific forms are syntax-related. Alright, 1 form (so far):
+            // - [Obsolete("Types with embedded references are not supported in this version of your compiler.", true)]
+            if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 2) {
+              if (ca.ConstructorArguments[1].Value is true) {
+                var message = ca.ConstructorArguments[0].Value as string;
+                return message == "Types with embedded references are not supported in this version of your compiler.";
+              }
+            }
+            break;
         }
         break;
       case "System.Runtime.CompilerServices":
@@ -379,6 +389,9 @@ internal class CSharpFormatter : CodeFormatter {
             return true;
           case "PreserveBaseOverridesAttribute":
             // Used to detect covariant return types.
+            return true;
+          case "ScopedRefAttribute":
+            // Mapped to "scoped" keyword.
             return true;
           case "TupleElementNamesAttribute":
             // Names extracted for use in tuple syntax.
@@ -781,6 +794,9 @@ internal class CSharpFormatter : CodeFormatter {
   private string Parameter(ParameterDefinition pd) {
     var sb = new StringBuilder();
     sb.Append(this.CustomAttributesInline(pd));
+    if (pd.IsScopedRef()) {
+      sb.Append("scoped ");
+    }
     if (pd.IsIn) {
       sb.Append("in ");
     }

--- a/Zastai.Build.ApiReference/CecilUtils.cs
+++ b/Zastai.Build.ApiReference/CecilUtils.cs
@@ -283,6 +283,10 @@ internal static class CecilUtils {
     => provider is not null && provider.HasCustomAttributes &&
        provider.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "IsReadOnlyAttribute"));
 
+  public static bool IsScopedRef(this ParameterDefinition? pd)
+    => pd is not null && pd.HasCustomAttributes &&
+       pd.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "ScopedRefAttribute"));
+
   public static bool IsUnmanaged(this GenericParameter? gp)
     => gp is not null && gp.HasCustomAttributes &&
        gp.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "IsUnmanagedAttribute"));
@@ -293,12 +297,6 @@ internal static class CecilUtils {
     var name = tr.Name;
     var backTick = name.IndexOf('`');
     return backTick >= 0 ? name.Substring(0, backTick) : name;
-  }
-
-  private static class Obsolete {
-
-    public const string RefStructs = "Types with embedded references are not supported in this version of your compiler.";
-
   }
 
   public static bool TryUnwrapNullable(this TypeReference tr, [NotNullWhen(true)] out TypeReference? unwrapped) {

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
@@ -40,6 +40,8 @@
     <ApiReferenceExcludeAttribute Include="System.Reflection.AssemblyVersionAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Resources.NeutralResourcesLanguageAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.CompilationRelaxationsAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute" />
+    <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.RefSafetyRulesAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute" />
 


### PR DESCRIPTION
This adds
`System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute` and `System.Runtime.CompilerServices.RefSafetyRulesAttribute` to the list of attributes that are excluded by default.

It also strips the specific `[Obsolete]` that is added to `ref struct` declarations by the compiler.

In addition, `[ScopedRef]` is now mapped to the `scoped` keyword.

Fixes #44.