### PR TITLE
Handle required members

### DIFF
--- a/Zastai.Build.ApiReference/CecilUtils.cs
+++ b/Zastai.Build.ApiReference/CecilUtils.cs
@@ -283,6 +283,10 @@ internal static class CecilUtils {
     => provider is not null && provider.HasCustomAttributes &&
        provider.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "IsReadOnlyAttribute"));
 
+  public static bool IsRequired(this IMemberDefinition? md)
+    => md is not null && md.HasCustomAttributes &&
+       md.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "RequiredMemberAttribute"));
+
   public static bool IsScopedRef(this ParameterDefinition? pd)
     => pd is not null && pd.HasCustomAttributes &&
        pd.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "ScopedRefAttribute"));


### PR DESCRIPTION
This interprets the attribute used to mark members (fields and properties) as `required`.

Fixes #49.