### PR TITLE
Change the package type to `Dependency`

### DIFF
--- a/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
+++ b/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
@@ -25,7 +25,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageType>MSBuildSdk</PackageType>
+    <PackageType>Dependency</PackageType>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 


### PR DESCRIPTION
`MSBuildSdk` is only appropriate to full SDKs, not for a package that just hooks an extra step into the build.

Fixes #51.