### PR TITLE
Improve enum handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ be created as part of the processing.
 
 Defaults to `false`.
 
+### EnableCharEnumHandling
+
+Enables special enum handing; if set to `true`, when an enum uses
+`ushort` as base type and all values are reasonably representable as
+characters, then character literals will be used.
+
+Defaults to `false`.
+
+### EnableHexEnumHandling
+
+Enables special enum handing; if set to `true`, when an enum is marked as
+`[Flags]` and all values either have a single bit or a single set of
+contiguous bits set, then hexadecimal literal will be used.
+
+Defaults to `false`.
+
 ### GenerateApiReference
 
 Determines whether API Reference sources will be generated for each

--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -259,7 +259,7 @@ internal class CSharpFormatter : CodeFormatter {
     if (fd.IsLiteral || isDecimalConstant) {
       sb.Append(" = ");
       if (fd.IsLiteral) {
-        sb.Append(fd.HasConstant ? this.Value(null, fd.Constant) : "/* constant value missing */");
+        sb.Append(fd.HasConstant ? this.Value(fd.FieldType, fd.Constant) : "/* constant value missing */");
       }
       else if (decimalConstantValue.HasValue) {
         sb.Append(this.Literal(decimalConstantValue.Value));

--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -138,7 +138,7 @@ internal class CSharpFormatter : CodeFormatter {
     return sb.ToString();
   }
 
-  protected override string EnumField(FieldDefinition fd, int indent, bool useCharacters) {
+  protected override string EnumField(FieldDefinition fd, int indent, EnumFieldValueMode mode) {
     var sb = new StringBuilder();
     sb.Append(' ', indent);
     if (!fd.IsPublic) {
@@ -150,24 +150,46 @@ internal class CSharpFormatter : CodeFormatter {
       if (!fd.HasConstant) {
         sb.Append("/* constant value missing */");
       }
-      // We currently only expect ushort values when using characters
-      else if (useCharacters && fd.Constant is ushort value) {
-        sb.Append(this.Literal((char) value));
-      }
       else {
-        // We expect only integral values, and we don't want any casts, or even any suffixes (because either they're all int, or the
-        // specific integer type is listed on the enum as a base type, making the interpretation unambiguous).
-        sb.Append(fd.Constant switch {
-          byte u8 => u8.ToString(CultureInfo.InvariantCulture),
-          int i32 => i32.ToString(CultureInfo.InvariantCulture),
-          long i64 => i64.ToString(CultureInfo.InvariantCulture),
-          sbyte i8 => i8.ToString(CultureInfo.InvariantCulture),
-          short i16 => i16.ToString(CultureInfo.InvariantCulture),
-          uint u32 => u32.ToString(CultureInfo.InvariantCulture),
-          ulong u64 => u64.ToString(CultureInfo.InvariantCulture),
-          ushort u16 => u16.ToString(CultureInfo.InvariantCulture),
-          _ => "/* unexpected field type */ " + this.Value(null, fd.Constant)
-        });
+        switch (mode) {
+          case EnumFieldValueMode.Character:
+            if (fd.Constant is ushort value) {
+              sb.Append(this.Literal((char) value));
+            }
+            else {
+              // should never happen, but fall back on the "normal" processing
+              goto case EnumFieldValueMode.Integer;
+            }
+            break;
+          case EnumFieldValueMode.Hexadecimal:
+            sb.Append(fd.Constant switch {
+              byte u8 => $"0x{u8:X2}",
+              int i32 => $"0x{i32:X8}",
+              long i64 => $"0x{i64:X16}",
+              sbyte i8 => $"0x{i8:X2}",
+              short i16 => $"0x{i16:X4}",
+              uint u32 => $"0x{u32:X8}",
+              ulong u64 => $"0x{u64:X16}",
+              ushort u16 => $"0x{u16:X4}",
+              _ => "/* unexpected field type */ " + this.Value(null, fd.Constant)
+            });
+            break;
+          case EnumFieldValueMode.Integer:
+            // We expect only integral values, and we don't want any casts, or even any suffixes (because either they're all int, or
+            // the specific integer type is listed on the enum as a base type, making the interpretation unambiguous).
+            sb.Append(fd.Constant switch {
+              byte u8 => u8.ToString(CultureInfo.InvariantCulture),
+              int i32 => i32.ToString(CultureInfo.InvariantCulture),
+              long i64 => i64.ToString(CultureInfo.InvariantCulture),
+              sbyte i8 => i8.ToString(CultureInfo.InvariantCulture),
+              short i16 => i16.ToString(CultureInfo.InvariantCulture),
+              uint u32 => u32.ToString(CultureInfo.InvariantCulture),
+              ulong u64 => u64.ToString(CultureInfo.InvariantCulture),
+              ushort u16 => u16.ToString(CultureInfo.InvariantCulture),
+              _ => "/* unexpected field type */ " + this.Value(null, fd.Constant)
+            });
+            break;
+        }
       }
     }
     else {

--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -138,7 +138,7 @@ internal class CSharpFormatter : CodeFormatter {
     return sb.ToString();
   }
 
-  protected override string EnumField(FieldDefinition fd, int indent) {
+  protected override string EnumField(FieldDefinition fd, int indent, bool useCharacters) {
     var sb = new StringBuilder();
     sb.Append(' ', indent);
     if (!fd.IsPublic) {
@@ -146,7 +146,29 @@ internal class CSharpFormatter : CodeFormatter {
     }
     sb.Append(fd.Name);
     if (fd.IsLiteral) {
-      sb.Append(" = ").Append(fd.HasConstant ? this.Value(null, fd.Constant) : " /* constant value missing */");
+      sb.Append(" = ");
+      if (!fd.HasConstant) {
+        sb.Append("/* constant value missing */");
+      }
+      // We currently only expect ushort values when using characters
+      else if (useCharacters && fd.Constant is ushort value) {
+        sb.Append(this.Literal((char) value));
+      }
+      else {
+        // We expect only integral values, and we don't want any casts, or even any suffixes (because either they're all int, or the
+        // specific integer type is listed on the enum as a base type, making the interpretation unambiguous).
+        sb.Append(fd.Constant switch {
+          byte u8 => u8.ToString(CultureInfo.InvariantCulture),
+          int i32 => i32.ToString(CultureInfo.InvariantCulture),
+          long i64 => i64.ToString(CultureInfo.InvariantCulture),
+          sbyte i8 => i8.ToString(CultureInfo.InvariantCulture),
+          short i16 => i16.ToString(CultureInfo.InvariantCulture),
+          uint u32 => u32.ToString(CultureInfo.InvariantCulture),
+          ulong u64 => u64.ToString(CultureInfo.InvariantCulture),
+          ushort u16 => u16.ToString(CultureInfo.InvariantCulture),
+          _ => "/* unexpected field type */ " + this.Value(null, fd.Constant)
+        });
+      }
     }
     else {
       sb.Append(" /* not a literal */");
@@ -1166,16 +1188,15 @@ internal class CSharpFormatter : CodeFormatter {
           baseType = null;
         }
       }
-      if (baseType is null && td.IsEnum) {
-        // Look for the special-named 'value__' field and use its type
-        if (td.HasFields) {
-          foreach (var fd in td.Fields) {
-            if (fd.IsSpecialName && fd.Name == "value__") {
-              // If it's Int32, leave it off
-              if (fd.FieldType != fd.Module.TypeSystem.Int32) {
-                baseType = fd.FieldType;
-              }
+      // For an enum, look for the special-named 'value__' field and use its type as the base type.
+      if (baseType is null && td is { IsEnum: true, HasFields: true }) {
+        foreach (var fd in td.Fields) {
+          if (fd.IsSpecialName && fd.Name == "value__") {
+            // If it's Int32, leave it off
+            if (fd.FieldType != fd.Module.TypeSystem.Int32) {
+              baseType = fd.FieldType;
             }
+            break;
           }
         }
       }

--- a/Zastai.Build.ApiReference/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.cs
@@ -14,6 +14,10 @@ internal abstract partial class CodeFormatter {
 
   private readonly ISet<string> _attributesToInclude = new HashSet<string>();
 
+  private bool _charEnumsEnabled = false;
+
+  private bool _hexEnumsEnabled = false;
+
   // FIXME: IReadOnlySet would be better, but is not available on .NET Framework.
   private ISet<string>? _runtimeFeatures;
 
@@ -94,6 +98,10 @@ internal abstract partial class CodeFormatter {
       }
     }
   }
+
+  public void EnableCharEnums(bool yes) => this._charEnumsEnabled = yes;
+
+  public void EnableHexEnums(bool yes) => this._hexEnumsEnabled = yes;
 
   protected abstract string EnumField(FieldDefinition fd, int indent, EnumFieldValueMode mode);
 
@@ -184,10 +192,10 @@ internal abstract partial class CodeFormatter {
     if (td.IsEnum) {
       yield return null;
       // First pass: determine the processing mode for the values.
-      var canUseCharacters = true;
+      var canUseCharacters = this._charEnumsEnabled;
       var canUseHex = false;
       // Currently, only use hex mode for [Flags] enums.
-      if (td.HasCustomAttributes) {
+      if (this._hexEnumsEnabled && td.HasCustomAttributes) {
         foreach (var ca in td.CustomAttributes) {
           var at = ca.AttributeType;
           if (at.Scope == at.Module.TypeSystem.CoreLibrary && at is { Namespace: "System", Name: "FlagsAttribute" }) {

--- a/Zastai.Build.ApiReference/EnumFieldValueMode.cs
+++ b/Zastai.Build.ApiReference/EnumFieldValueMode.cs
@@ -1,0 +1,15 @@
+﻿namespace Zastai.Build.ApiReference;
+
+/// <summary>The way in which the value of an enum field should be represented.</summary>
+public enum EnumFieldValueMode {
+
+  /// <summary>Use character literals.</summary>
+  Character,
+
+  /// <summary>Use hexadecimal literals.</summary>
+  Hexadecimal,
+
+  /// <summary>Use integer literals.</summary>
+  Integer,
+
+}

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
@@ -111,6 +111,20 @@
       <_ApiReferenceCommandLineOptions Include="-r &quot;%(_DirectoriesContainingReferencedAssemblies.Identity)&quot;" />
     </ItemGroup>
 
+    <!-- Enum Handling -->
+    <ItemGroup>
+      <_ApiReferenceEnumHandling Include="char" Condition=" '$(EnableCharEnumHandling)' == 'true' " />
+      <_ApiReferenceEnumHandling Include="hex-flags" Condition=" '$(EnableHexEnumHandling)' == 'true' " />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_ApiReferenceEnumHandling>@(_ApiReferenceEnumHandling, ',')</_ApiReferenceEnumHandling>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ApiReferenceCommandLineOptions Include="-eh &quot;$(_ApiReferenceEnumHandling)&quot;" />
+    </ItemGroup>
+
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetFullPath('$(ApiReferenceOutputPath)'))))"
              Condition=" '$(CreateApiReferenceOutputDir)' == 'true' "/>
 


### PR DESCRIPTION
As a general improvement, enum fields will no longer get casts or suffixes when the enum is not based on `int`.

In addition, two special types of handling can be enabled via properties:
- `EnableCharEnumHandling`
  When an enum uses `ushort` as base type and all values can be reasonably interpreted as characters, then character literals will be used.
- `EnableHexEnumHandling`
  When an enum is marked as `[Flags]` and all values either have a single bit or a single set of contiguous bits set, then hexadecimal literal will be used.

Both default to `false`, so this special processing is opt-in.

Fixes #59.
