### PR TITLE
Fix issues with properties (and indexers in particular)

### DIFF
--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -1082,13 +1082,7 @@ internal class CSharpFormatter : CodeFormatter {
         sb.Append("required ");
       }
       sb.Append(this.TypeName(pd.PropertyType, pd)).Append(' ');
-      // FIXME: Or should this only be done when the type has [System.Reflection.DefaultMemberAttribute("Item")]?
-      if (pd.HasParameters && pd.Name == "Item") {
-        sb.Append("this");
-      }
-      else {
-        sb.Append(pd.Name);
-      }
+      sb.Append(this.PropertyName(pd));
       sb.Append(this.Parameters(pd)).Append(" {");
       yield return sb.ToString();
     }
@@ -1138,6 +1132,11 @@ internal class CSharpFormatter : CodeFormatter {
     }
     sb.Append(';');
     yield return sb.ToString();
+  }
+
+  protected override string PropertyName(PropertyDefinition pd) {
+    // FIXME: Or should this only be done when the type has [System.Reflection.DefaultMemberAttribute("Item")]?
+    return pd is { HasParameters: true, Name: "Item" } ? "this" : pd.Name;
   }
 
   protected override IEnumerable<string?> Type(TypeDefinition td, int indent) {

--- a/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.Comparers.cs
@@ -1,6 +1,6 @@
 ﻿ namespace Zastai.Build.ApiReference;
 
-internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
+internal abstract partial class CodeFormatter : IComparer<MethodDefinition>, IComparer<PropertyDefinition> {
 
   public int Compare(MethodDefinition? x, MethodDefinition? y) {
     if (object.ReferenceEquals(x, y)) {
@@ -56,7 +56,7 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
     else if (y.HasGenericParameters) {
       return -1;
     }
-    // Level Three: Parameter types.
+    // Level 3: Parameter types.
     if (x.HasParameters && y.HasParameters) {
       using var walker1 = x.Parameters.GetEnumerator();
       using var walker2 = y.Parameters.GetEnumerator();
@@ -90,6 +90,66 @@ internal abstract partial class CodeFormatter : IComparer<MethodDefinition> {
     // The return type _should not_ matter, but let's include that in the sequence just in case.
     // FIXME: Or should this use the invariant culture?
     return string.Compare(xReturnType, yReturnType, StringComparison.Ordinal);
+  }
+
+  public int Compare(PropertyDefinition? x, PropertyDefinition? y) {
+    if (object.ReferenceEquals(x, y)) {
+      return 0;
+    }
+    if (x is null) {
+      return -1;
+    }
+    if (y is null) {
+      return +1;
+    }
+    // Level 1: The property name.
+    {
+      var name1 = this.PropertyName(x);
+      var name2 = this.PropertyName(y);
+      // FIXME: Or should this use the invariant culture?
+      var cmp = string.Compare(name1, name2, StringComparison.Ordinal);
+      if (cmp != 0) {
+        return cmp;
+      }
+    }
+    // Level 2: Parameter types.
+    if (x.HasParameters && y.HasParameters) {
+      using var walker1 = x.Parameters.GetEnumerator();
+      using var walker2 = y.Parameters.GetEnumerator();
+      while (walker1.MoveNext()) {
+        if (!walker2.MoveNext()) {
+          return +1;
+        }
+        // This uses the formatter-specific idea of a type's string form. That also means that Int16 sorts after Int32 for the C#
+        // formatter (because "short" follows "int").
+        var type1 = walker1.Current?.ParameterType;
+        var name1 = type1 is null ? null : this.TypeName(type1, x);
+        var type2 = walker2.Current?.ParameterType;
+        var name2 = type2 is null ? null : this.TypeName(type2, y);
+        // FIXME: Or should this use the invariant culture?
+        var cmp = string.Compare(name1, name2, StringComparison.Ordinal);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+      if (walker2.MoveNext()) {
+        return -1;
+      }
+    }
+    else if (x.HasParameters) {
+      return +1;
+    }
+    else if (y.HasParameters) {
+      return -1;
+    }
+    // FIXME: Are there other things to compare?
+    // The property type _should not_ matter, but let's include that in the sequence just in case.
+    // FIXME: Or should this use the invariant culture?
+    {
+      var name1 = this.TypeName(x.PropertyType, x);
+      var name2 = this.TypeName(y.PropertyType, y);
+      return string.Compare(name1, name2, StringComparison.Ordinal);
+    }
   }
 
 }

--- a/Zastai.Build.ApiReference/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.cs
@@ -495,9 +495,6 @@ internal abstract partial class CodeFormatter {
         }
       }
     }
-    if (properties.Count == 0) {
-      yield break;
-    }
     foreach (var overloads in parametrizedProperties.Values) {
       foreach (var pd in overloads.Values) {
         yield return null;


### PR DESCRIPTION
Before, when a type containing parametrized properties (like indexers) but no normal properties, the indexers were not emitted.

Use specific sorting for properties too, mainly for indexers (which have parameters); this involves:
- adding a `PropertyName` method to `CodeFormatter` and extract its implementation in `CSharpFormatter` from the `Property` method
- implement `IComparer<PropertyDefinition>` in `CodeFormatter`
- switching the processing for properties to use a `SortedSet`
