### PR TITLE
C# 13: Detect `allows ref struct` on generic parameter

### DIFF
--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -401,6 +401,13 @@ internal class CSharpFormatter : CodeFormatter {
       }
       sb.Append("new()");
     }
+    // Hopefully at some point: if (gp.AllowsByRefLike / gp.HasAllowByRefLike)
+    if (((int) gp.Attributes & 0x20) != 0) {
+      if (!first) {
+        sb.Append(", ");
+      }
+      sb.Append("allows ref struct");
+    }
     return sb.ToString();
   }
 


### PR DESCRIPTION
This has to use a raw value because there is no Cecil release yet which provides nice API for it.