### PR TITLE
Enable documenting internal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Determines whether the output files are registered in `@(FileWrites)`.
 
 Defaults to `false`.
 
+### VisibilityForApiReference
+
+Determines which items are included in API Reference sources. Can be
+either `public`, to only include public API, or `internal`, to also
+include elements marked as `internal` or `private protected`.
+
+Defaults to `public`.
+
 ## Configuration - Which Attributes to Include
 
 The choice of which attributes to consider part of the public API is

--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -48,8 +48,14 @@ internal class CSharpFormatter : CodeFormatter {
     if (md.IsPublic) {
       sb.Append("public ");
     }
+    else if (md.IsAssembly) {
+      sb.Append("internal ");
+    }
     else if (md.IsFamily) {
       sb.Append("protected ");
+    }
+    else if (md.IsFamilyAndAssembly) {
+      sb.Append("private protected ");
     }
     else if (md.IsFamilyOrAssembly) {
       sb.Append("protected internal ");
@@ -281,11 +287,20 @@ internal class CSharpFormatter : CodeFormatter {
     if (fd.IsPublic) {
       sb.Append("public ");
     }
+    else if (fd.IsAssembly) {
+      sb.Append("internal ");
+    }
     else if (fd.IsFamily) {
       sb.Append("protected ");
     }
+    else if (fd.IsFamilyAndAssembly) {
+      sb.Append("private protected ");
+    }
     else if (fd.IsFamilyOrAssembly) {
       sb.Append("protected internal ");
+    }
+    else {
+      sb.Append("/* unexpected accessibility */ ");
     }
     if (fd.IsRequired()) {
       sb.Append("required ");
@@ -1213,18 +1228,24 @@ internal class CSharpFormatter : CodeFormatter {
       yield return sb.ToString();
       sb.Clear();
     }
-    if (!td.IsPublicApi()) {
-      yield return this.LineComment($"ERROR: Type {td} has unsupported access: {td.Attributes}.");
-    }
     sb.Append(' ', indent);
     if (td.IsPublic || td.IsNestedPublic) {
       sb.Append("public ");
     }
+    else if (td.IsNestedAssembly || td.IsNotPublic) {
+      sb.Append("internal ");
+    }
     else if (td.IsNestedFamily) {
       sb.Append("protected ");
     }
+    else if (td.IsNestedFamilyAndAssembly) {
+      sb.Append("private protected ");
+    }
     else if (td.IsNestedFamilyOrAssembly) {
       sb.Append("protected internal ");
+    }
+    else {
+      sb.Append("/* unexpected accessibility */ ");
     }
     if (td.IsDelegate(out var invoke)) {
       sb.Append("delegate ");

--- a/Zastai.Build.ApiReference/CecilUtils.cs
+++ b/Zastai.Build.ApiReference/CecilUtils.cs
@@ -258,6 +258,15 @@ internal static class CecilUtils {
     return false;
   }
 
+  // FIXME: Can the remove method differ? Does it matter?
+  public static bool IsInternalApi(this EventDefinition ed) => ed.AddMethod.IsInternalApi();
+
+  public static bool IsInternalApi(this FieldDefinition fd) => fd.IsAssembly || fd.IsFamilyAndAssembly;
+
+  public static bool IsInternalApi(this MethodDefinition md) => md.IsAssembly || md.IsFamilyAndAssembly;
+
+  public static bool IsInternalApi(this TypeDefinition td) => td.IsNestedAssembly || td.IsNestedFamilyAndAssembly || td.IsNotPublic;
+
   public static bool IsLocalType(this TypeReference tr) => tr.Scope == tr.Module;
 
   public static bool IsLocalType(this TypeReference tr, string? ns) => tr.IsLocalType() && tr.IsNamed(ns);

--- a/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
+++ b/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
@@ -17,7 +17,7 @@
     <PackageReadMeFile>README.md</PackageReadMeFile>
     <PackageTags>C# API Reference</PackageTags>
     <Title>API Reference Generator</Title>
-    <Version>2.1.1-pre</Version>
+    <Version>2.2.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
@@ -36,6 +36,9 @@
     <!-- Detetermines whether API reference sources should be generated. -->
     <GenerateApiReference Condition=" '$(GenerateApiReference)' == '' ">true</GenerateApiReference>
 
+    <!-- Detetermines what elements should be included. -->
+    <VisibilityForApiReference Condition=" '$(VisibilityForApiReference)' == '' ">public</VisibilityForApiReference>
+
     <!-- The program needed to run Mono executables. -->
     <MonoRunner Condition=" '$(MonoRunner)' == '' ">mono --runtime=v4.0.30319</MonoRunner>
 
@@ -93,6 +96,21 @@
       <_ApiReferenceCommandLineOptions Include="-ea &quot;%(_ApiReferenceExcludeAttributes.Identity)&quot;" />
     </ItemGroup>
 
+    <!-- Enum Handling -->
+    <ItemGroup>
+      <_ApiReferenceEnumHandling Include="binary" Condition=" '$(EnableBinaryEnumHandling)' == 'true' " />
+      <_ApiReferenceEnumHandling Include="char" Condition=" '$(EnableCharEnumHandling)' == 'true' " />
+      <_ApiReferenceEnumHandling Include="hex" Condition=" '$(EnableHexEnumHandling)' == 'true' " />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_ApiReferenceEnumHandling>@(_ApiReferenceEnumHandling, ',')</_ApiReferenceEnumHandling>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ApiReferenceCommandLineOptions Include="-eh &quot;$(_ApiReferenceEnumHandling)&quot;" />
+    </ItemGroup>
+
     <!-- Reference Path Configured: Use. -->
     <ItemGroup Condition=" '$(ApiReferenceLibraryPath)' != '' ">
       <_ConfiguredDirectoriesContainingReferencedAssemblies Include="$(ApiReferenceLibraryPath)" />
@@ -111,19 +129,10 @@
       <_ApiReferenceCommandLineOptions Include="-r &quot;%(_DirectoriesContainingReferencedAssemblies.Identity)&quot;" />
     </ItemGroup>
 
-    <!-- Enum Handling -->
+    <!-- Visibility to Include: Pass -->
     <ItemGroup>
-      <_ApiReferenceEnumHandling Include="binary" Condition=" '$(EnableBinaryEnumHandling)' == 'true' " />
-      <_ApiReferenceEnumHandling Include="char" Condition=" '$(EnableCharEnumHandling)' == 'true' " />
-      <_ApiReferenceEnumHandling Include="hex" Condition=" '$(EnableHexEnumHandling)' == 'true' " />
-    </ItemGroup>
-
-    <PropertyGroup>
-      <_ApiReferenceEnumHandling>@(_ApiReferenceEnumHandling, ',')</_ApiReferenceEnumHandling>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_ApiReferenceCommandLineOptions Include="-eh &quot;$(_ApiReferenceEnumHandling)&quot;" />
+      <_ApiReferenceCommandLineOptions Include="-v" />
+      <_ApiReferenceCommandLineOptions Include="$(VisibilityForApiReference)" />
     </ItemGroup>
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetFullPath('$(ApiReferenceOutputPath)'))))"


### PR DESCRIPTION
A new command-line option has been added, `-v VISIBILITY` to choose between only public API (`public`; the default) and including internal API (`internal`; adds items marked `internal` or `private protected`, but *not* `private`).

This option has a corresponding `VisibilityForApiReference` configuration property.

This bumps the version to 2.2.0-pre (because of the added feature).