### PR TITLE
List `protected internal` as just `protected`

### DIFF
--- a/Zastai.Build.ApiReference/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference/CSharpFormatter.cs
@@ -58,7 +58,10 @@ internal class CSharpFormatter : CodeFormatter {
       sb.Append("private protected ");
     }
     else if (md.IsFamilyOrAssembly) {
-      sb.Append("protected internal ");
+      sb.Append("protected ");
+      if (this.IncludeInternals) {
+        sb.Append("internal ");
+      }
     }
     else {
       sb.Append("/* unexpected accessibility */ ");
@@ -297,7 +300,10 @@ internal class CSharpFormatter : CodeFormatter {
       sb.Append("private protected ");
     }
     else if (fd.IsFamilyOrAssembly) {
-      sb.Append("protected internal ");
+      sb.Append("protected ");
+      if (this.IncludeInternals) {
+        sb.Append("internal ");
+      }
     }
     else {
       sb.Append("/* unexpected accessibility */ ");
@@ -1242,7 +1248,10 @@ internal class CSharpFormatter : CodeFormatter {
       sb.Append("private protected ");
     }
     else if (td.IsNestedFamilyOrAssembly) {
-      sb.Append("protected internal ");
+      sb.Append("protected ");
+      if (this.IncludeInternals) {
+        sb.Append("internal ");
+      }
     }
     else {
       sb.Append("/* unexpected accessibility */ ");

--- a/Zastai.Build.ApiReference/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference/CodeFormatter.cs
@@ -20,8 +20,6 @@ internal abstract partial class CodeFormatter {
 
   private bool _hexEnumsEnabled;
 
-  private bool _includeInternals;
-
   // FIXME: IReadOnlySet would be better, but is not available on .NET Framework.
   private ISet<string>? _runtimeFeatures;
 
@@ -362,7 +360,7 @@ internal abstract partial class CodeFormatter {
     }
   }
 
-  public void IncludeInternals(bool yes) => this._includeInternals = yes;
+  public bool IncludeInternals { get; set; }
 
   protected abstract string LineComment(string comment);
 
@@ -556,14 +554,14 @@ internal abstract partial class CodeFormatter {
     return this._attributesToExclude.All(pattern => !name.Matches(pattern));
   }
 
-  private bool ShouldInclude(EventDefinition ed) => ed.IsPublicApi() || (this._includeInternals && ed.IsInternalApi());
+  private bool ShouldInclude(EventDefinition ed) => ed.IsPublicApi() || (this.IncludeInternals && ed.IsInternalApi());
 
-  private bool ShouldInclude(FieldDefinition fd) => fd.IsPublicApi() || (this._includeInternals && fd.IsInternalApi());
+  private bool ShouldInclude(FieldDefinition fd) => fd.IsPublicApi() || (this.IncludeInternals && fd.IsInternalApi());
 
   private bool ShouldInclude(MethodDefinition? md)
-    => md is not null && (md.IsPublicApi() || (this._includeInternals && md.IsInternalApi()));
+    => md is not null && (md.IsPublicApi() || (this.IncludeInternals && md.IsInternalApi()));
 
-  private bool ShouldInclude(TypeDefinition td) => td.IsPublicApi() || (this._includeInternals && td.IsInternalApi());
+  private bool ShouldInclude(TypeDefinition td) => td.IsPublicApi() || (this.IncludeInternals && td.IsInternalApi());
 
   private IEnumerable<string?> TopLevelAttributes(AssemblyDefinition ad) {
     foreach (var line in this.CustomAttributes(ad)) {

--- a/Zastai.Build.ApiReference/Program.cs
+++ b/Zastai.Build.ApiReference/Program.cs
@@ -136,7 +136,7 @@ public static class Program {
     formatter.EnableHexEnums(handleHexEnums);
     formatter.ExcludeCustomAttributes(excludedAttributes);
     formatter.IncludeCustomAttributes(includedAttributes);
-    formatter.IncludeInternals(includeInternals);
+    formatter.IncludeInternals = includeInternals;
     try {
       using var ad = AssemblyDefinition.ReadAssembly(assembly, Program.CreateReaderParameters(assembly, dependencyPath));
       using var reference = referenceSource == "-" ? Console.Out : new StreamWriter(File.Create(referenceSource), Encoding.UTF8);


### PR DESCRIPTION
Unless internals are included in the reference, such items are no different from plain `protected` items and so should be listed as such.

Fixes #74.