### PR TITLE
Correct inclusion of nested types

### DIFF
--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -726,7 +726,7 @@ public abstract partial class CodeFormatter {
     }
     var nestedTypes = new SortedDictionary<string, TypeDefinition>();
     foreach (var type in td.NestedTypes) {
-      if (!this.ShouldInclude(td)) {
+      if (!this.ShouldInclude(type)) {
         continue;
       }
       if (nestedTypes.TryGetValue(type.Name, out var previousType)) {


### PR DESCRIPTION
The "should be included" test for nested types was actually (re)testing the enclosing type (which is always true, so all nested types were included).

Fixes #80.