### PR TITLE
Refactor the build properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!-- Chain to parent settings. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)..'))"
+          Condition=" Exists($([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)..'))) "/>
+
+  <PropertyGroup>
+    <Copyright>Copyright © 2022, 2023, 2024 Tim Van Holder. All rights reserved.</Copyright>
+    <RepositoryUrl>https://github.com/Zastai/Zastai.Build.ApiReference</RepositoryUrl>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageIcon>package-icon.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>$(RepositoryUrl)/blob/main/README.md</PackageProjectUrl>
+    <PackageReadMeFile>README.md</PackageReadMeFile>
+    <Version>3.0.0-pre</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_ReadMeFile>README.md</_ReadMeFile>
+    <_ReadMeFile Condition=" !Exists('$(_ReadMeFile)') ">$(MSBuildThisFileDirectory)\README.md</_ReadMeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Pack="true" PackagePath="" Include="$(MSBuildThisFileDirectory)\LICENSE.md"/>
+    <None Pack="true" PackagePath="" Include="$(MSBuildThisFileDirectory)\package-icon.png"/>
+    <None Pack="true" PackagePath="" Include="$(_ReadMeFile)"/>
+  </ItemGroup>
+
+</Project>

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Zastai.Build.ApiReference.Library/Zastai.Build.ApiReference.Library.csproj
+++ b/Zastai.Build.ApiReference.Library/Zastai.Build.ApiReference.Library.csproj
@@ -1,55 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Copyright>Copyright © 2022, 2023, 2024 Tim Van Holder. All rights reserved.</Copyright>
-    <RepositoryUrl>https://github.com/Zastai/Zastai.Build.ApiReference</RepositoryUrl>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>Provides an API to generate an API reference for a .NET assembly, to allow easy API diffs.</Description>
-    <PackageIcon>package-icon.png</PackageIcon>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>$(RepositoryUrl)/blob/main/README.md</PackageProjectUrl>
-    <PackageReadMeFile>README.md</PackageReadMeFile>
     <PackageTags>C# API Reference</PackageTags>
     <RootNamespace>Zastai.Build.ApiReference</RootNamespace>
     <Title>API Reference Generator Library</Title>
-    <Version>3.0.0-pre</Version>
-  </PropertyGroup>
-
-  <PropertyGroup>
   </PropertyGroup>
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <LangVersion>12</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="../LICENSE.md">
-      <Pack>true</Pack>
-      <PackagePath>LICENSE.md</PackagePath>
-    </None>
-    <None Include="README.md">
-      <Pack>true</Pack>
-      <PackagePath>README.md</PackagePath>
-    </None>
-    <None Include="../package-icon.png">
-      <Pack>true</Pack>
-      <PackagePath/>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/Zastai.Build.ApiReference.Tool/README.md
+++ b/Zastai.Build.ApiReference.Tool/README.md
@@ -1,4 +1,4 @@
-# dotnet-api-reference [![Build Status][CI-S]][CI-L] [![NuGet Package Version][NuGet-S]][NuGet-L]
+# Zastai.Build.ApiReference.Tool [![Build Status][CI-S]][CI-L] [![NuGet Package Version][NuGet-S]][NuGet-L]
 
 This is a simple command-line tool to enable generating an API reference
 source for a .NET assembly.
@@ -10,7 +10,7 @@ source for a .NET assembly.
 To install the tool as part of a specific solution, run
 
 ```pwsh
-dotnet tool install dotnet-api-reference --create-manifest-if-needed
+dotnet tool install Zastai.Build.ApiReference.Tool --create-manifest-if-needed
 ```
 
 from the solution folder. This will create a tool manifest
@@ -26,7 +26,7 @@ When committed, the tool manifest allows using `dotnet tool restore` to
 To install it globally, for use anywhere on the machine, run
 
 ```pwsh
-dotnet tool install -g dotnet-api-reference
+dotnet tool install -g Zastai.Build.ApiReference.Tool
 ```
 
 This will enable running the tool using just `dotnet-api-reference`.

--- a/Zastai.Build.ApiReference.Tool/Zastai.Build.ApiReference.Tool.csproj
+++ b/Zastai.Build.ApiReference.Tool/Zastai.Build.ApiReference.Tool.csproj
@@ -1,57 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <PackAsTool>true</PackAsTool>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <Copyright>Copyright © 2024 Tim Van Holder. All rights reserved.</Copyright>
-    <RepositoryUrl>https://github.com/Zastai/Zastai.Build.ApiReference</RepositoryUrl>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>dotnet-api-reference</AssemblyName>
     <Description>This tool generates an API reference for a .NET assembly, to allow easy API diffs.</Description>
-    <PackageIcon>package-icon.png</PackageIcon>
     <PackageId>$(MSBuildProjectName)</PackageId>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>$(RepositoryUrl)/blob/main/README.md</PackageProjectUrl>
-    <PackageReadMeFile>README.md</PackageReadMeFile>
     <PackageTags>C# API Reference</PackageTags>
     <Title>API Reference Generator Tool</Title>
-    <Version>3.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <LangVersion>12</LangVersion>
-    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Zastai.Build.ApiReference.Library\Zastai.Build.ApiReference.Library.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="../LICENSE.md">
-      <Pack>true</Pack>
-      <PackagePath>LICENSE.md</PackagePath>
-    </None>
-    <None Include="README.md">
-      <Pack>true</Pack>
-      <PackagePath>README.md</PackagePath>
-    </None>
-    <None Include="../package-icon.png">
-      <Pack>true</Pack>
-      <PackagePath/>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/Zastai.Build.ApiReference.sln
+++ b/Zastai.Build.ApiReference.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
 		README.md = README.md
+		Directory.Build.props = Directory.Build.props
+		LICENSE.md = LICENSE.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{9D3966CD-4AE3-48BF-A058-4AF07F6FDCD2}"

--- a/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
+++ b/Zastai.Build.ApiReference/Zastai.Build.ApiReference.csproj
@@ -1,26 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <Copyright>Copyright © 2022, 2023, 2024 Tim Van Holder. All rights reserved.</Copyright>
-    <RepositoryUrl>https://github.com/Zastai/Zastai.Build.ApiReference</RepositoryUrl>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
     <Description>This package generates an API reference for the project it's added to, to allow easy API diffs.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <PackageIcon>package-icon.png</PackageIcon>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>$(RepositoryUrl)/blob/main/README.md</PackageProjectUrl>
-    <PackageReadMeFile>README.md</PackageReadMeFile>
     <PackageTags>C# API Reference</PackageTags>
     <PackageType>Dependency</PackageType>
     <Title>API Reference Generator</Title>
-    <Version>3.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,13 +21,6 @@
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
     <!-- However, that then triggers thr NU5128 warning (and possibly NU5100 too). -->
     <NoWarn>$(NoWarn);NU5100;NU5128</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <LangVersion>12</LangVersion>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,18 +35,6 @@
     <None Include="build/*.props;build/*.targets">
       <Pack>true</Pack>
       <PackagePath>build/%(Filename)%(Extension)</PackagePath>
-    </None>
-    <None Include="../LICENSE.md">
-      <Pack>true</Pack>
-      <PackagePath>LICENSE.md</PackagePath>
-    </None>
-    <None Include="README.md">
-      <Pack>true</Pack>
-      <PackagePath>README.md</PackagePath>
-    </None>
-    <None Include="../package-icon.png">
-      <Pack>true</Pack>
-      <PackagePath/>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
This introduces a `Directory.Build.props` file to hold the elements that are shared between the projects.

This also fixes the README for the tool project (it was not referring to the correct package name).