### PR TITLE
Fix NuGet API key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         subject-path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: "Publish: GitHub Packages"
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg --skip-duplicate -k ${{secrets.GITHUB_TOKEN}} -s https://nuget.pkg.github.com/zastai/index.json"
+      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
     - name: "Publish: nuget.org"
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg --skip-duplicate -k ${{secrets.GITHUB_TOKEN}} -s https://api.nuget.org/v3/index.json"
+      run: "dotnet nuget push */bin/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/Zastai.Build.ApiReference/README.md
+++ b/Zastai.Build.ApiReference/README.md
@@ -17,7 +17,7 @@ behaviour:
 The format to use for the API Reference source.
 
 Supported Values: `csharp` (or `cs`) for C#, and `csharp-markdown`
-(or `cs-md`) for MarkDown-with-C#. Case does not matter.
+(or `cs-md`) for Markdown-with-C#. Case does not matter.
 
 ### ApiReferenceLibraryPath
 


### PR DESCRIPTION
This also corrects a remaining use of "MarkDown" to "Markdown".