### PR TITLE
Update the build environment to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      dotnet-version: 9.0.x
+      dotnet-version: 10.0.x
     permissions:
       attestations: write
       id-token: write
@@ -25,12 +25,13 @@ jobs:
 
     steps:
     - name: Check out the project
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set up .NET ${{env.dotnet-version}}
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       id: setup
       with:
         dotnet-version: ${{env.dotnet-version}}
+        dotnet-quality: ga
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
@@ -38,19 +39,19 @@ jobs:
     - name: Run build script (${{matrix.configuration}})
       run: pwsh ./build-package.ps1 -WithBinLog -Configuration ${{matrix.configuration}}
     - name: "Artifact: MSBuild Logs"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: failure()
       with:
         name: MSBuild Logs (${{matrix.configuration}})
         path: msbuild.*.binlog
     - name: "Artifact: NuGet Packages"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: NuGet Packages (${{matrix.configuration}})
         path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: "Attestations: NuGet Packages"
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      uses: actions/attest-build-provenance@v2
+      uses: actions/attest-build-provenance@v3
       with:
         subject-path: "**/bin/${{matrix.configuration}}/*.nupkg"
     - name: "Publish: GitHub Packages"

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Labeler
@@ -18,4 +18,3 @@ jobs:
           yaml-file: .github/github-labels.yml
           skip-delete: false
           dry-run: false
-          exclude:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
           Condition=" Exists($([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)..'))) "/>
 
   <PropertyGroup>
-    <Copyright>Copyright © 2022, 2023, 2024 Tim Van Holder. All rights reserved.</Copyright>
+    <Copyright>Copyright © 2022, 2023, 2024, 2025 Tim Van Holder. All rights reserved.</Copyright>
     <RepositoryUrl>https://github.com/Zastai/Zastai.Build.ApiReference</RepositoryUrl>
   </PropertyGroup>
 
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ImplicitUsings>disable</ImplicitUsings>
-    <LangVersion>12</LangVersion>
+    <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Zastai.Build.ApiReference.Tool/Zastai.Build.ApiReference.Tool.csproj
+++ b/Zastai.Build.ApiReference.Tool/Zastai.Build.ApiReference.Tool.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This sets up .NET 10 for the build actions and adjusts the sandbox project to target `net10.0`. The tool targets `net8.0` and `net10.0`.

The various GitHub actions were updated to their latest versions.