### PR TITLE
Handle extension blocks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>$(RepositoryUrl)/blob/main/README.md</PackageProjectUrl>
     <PackageReadMeFile>README.md</PackageReadMeFile>
-    <Version>3.0.1-pre</Version>
+    <Version>3.1.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -59,7 +59,7 @@ public class CSharpFormatter : CodeFormatter {
     public readonly MethodDefinition? Method = method;
 
     /// <summary>The enclosing type for this context, if applicable.</summary>
-    public readonly TypeDefinition? Type = type;
+    public readonly TypeDefinition? Type = type ?? method?.DeclaringType;
 
     /// <summary>The current value index for <c>[Dynamic]</c> attribute checks.</summary>
     public int DynamicIndex;
@@ -328,6 +328,76 @@ public class CSharpFormatter : CodeFormatter {
   }
 
   /// <inheritdoc />
+  protected override IEnumerable<string?> ExtensionBlock(TypeDefinition td, int indent) {
+    // It is not clear whether a <G> class will always have a single <M> class in it, but given that memmbers get attributes linking
+    // to the <M> class name, let's assume there can be multiples.
+    if (!td.HasNestedTypes) {
+      yield return null;
+      var sb = new StringBuilder();
+      sb.Append(' ', indent).Append("/* extension block group class contains no marker classes */");
+      yield return sb.ToString();
+    }
+    foreach (var markerType in td.NestedTypes) {
+      yield return null;
+      if (markerType is not { IsSpecialName: true } || !markerType.Name.StartsWith("<M>")) {
+        var sb = new StringBuilder();
+        sb.Append(' ', indent).Append("/* extension block group class contains unexpected non-marker class */");
+        yield return sb.ToString();
+        continue;
+      }
+      // FIXME: Or should there be a single context at the <G> level?
+      var tnc = new TypeNameContext(markerType, null, markerType);
+      {
+        var sb = new StringBuilder();
+        sb.Append(' ', indent).Append("extension");
+        sb.Append(this.GenericParameters(markerType, tnc));
+        {
+          // FIXME: Is the marker type supposed to contain anything other than the special `<Extension>$` method?
+          var markerMethod = markerType.HasMethods && markerType.Methods.Count == 1 ? markerType.Methods[0] : null;
+          if (markerMethod is { IsSpecialName: true, IsCompilerGenerated: true, Name: "<Extension>$" }) {
+            sb.Append(this.Parameters(markerMethod));
+          }
+          else {
+            sb.Append("(/* no marker method */)");
+          }
+        }
+        {
+          var constraints = this.GenericParameterConstraints(markerType, 0).ToList();
+          if (constraints.Count > 1) {
+            yield return sb.ToString();
+            sb.Clear();
+            sb.Append(' ', indent + 2);
+            while (constraints.Count > 1) {
+              sb.Append(constraints[0]);
+              constraints.RemoveAt(0);
+            }
+            yield return sb.ToString();
+            sb.Clear();
+            sb.Append(' ', indent + 1);
+          }
+          if (constraints.Count == 1) {
+            sb.Append(' ').Append(constraints[0]);
+          }
+        }
+        sb.Append(' ').Append('{');
+        yield return sb.ToString();
+      }
+      foreach (var line in this.Properties(td, indent + 2)) {
+        yield return line;
+      }
+      foreach (var line in this.Methods(td, indent + 2)) {
+        yield return line;
+      }
+      yield return null;
+      {
+        var sb = new StringBuilder();
+        sb.Append(' ', indent).Append('}');
+        yield return sb.ToString();
+      }
+    }
+  }
+
+  /// <inheritdoc />
   protected override string Field(FieldDefinition fd, int indent) {
     var sb = new StringBuilder();
     sb.Append(' ', indent);
@@ -532,6 +602,7 @@ public class CSharpFormatter : CodeFormatter {
         switch (at.Name) {
           case "AsyncStateMachineAttribute":
           case "CompilerGeneratedAttribute":
+          case "ExtensionMarkerAttribute":
           case "IteratorStateMachineAttribute":
           case "ReferenceAssemblyAttribute":
             // Guaranteed not to be relevant to the API.
@@ -1447,6 +1518,9 @@ public class CSharpFormatter : CodeFormatter {
     foreach (var line in this.Methods(td, indent + 2)) {
       yield return line;
     }
+    foreach (var line in this.ExtensionBlocks(td, indent + 2)) {
+      yield return line;
+    }
     foreach (var line in this.NestedTypes(td, indent + 2)) {
       yield return line;
     }
@@ -1774,6 +1848,10 @@ public class CSharpFormatter : CodeFormatter {
           declaringType = null;
           break;
         }
+      }
+      if (declaringType is not null && declaringType == tnc.Type) {
+        // FIXME: Is this always appropriate? Should this traverse the context type's declaring types too?
+        declaringType = null;
       }
       if (declaringType is not null) {
         // FIXME: Does this need a context? Should it affect the indexes?

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -114,7 +114,7 @@ public class CSharpFormatter : CodeFormatter {
     else if (md.IsVirtual) {
       // For some reason, static virtual methods in interfaces have IsReuseSlot set; that's currently the only situation where
       // static+virtual is valid, so we can just look at IsStatic to ignore the IsReuseSlot.
-      var isOverride = md is { IsReuseSlot: true, IsStatic: false } || (md.IsNewSlot && md.HasCovariantReturn());
+      var isOverride = md is { IsReuseSlot: true, IsStatic: false } || (md.IsNewSlot && md.HasCovariantReturn);
       sb.Append(isOverride ? "override " : "virtual ");
     }
     return sb.ToString();
@@ -352,7 +352,7 @@ public class CSharpFormatter : CodeFormatter {
     else {
       sb.Append("/* unexpected accessibility */ ");
     }
-    if (fd.IsRequired()) {
+    if (fd.IsRequired) {
       sb.Append("required ");
     }
     var isDecimalConstant = false;
@@ -412,7 +412,7 @@ public class CSharpFormatter : CodeFormatter {
     sb.Append("where ").Append(gp.Name).Append(" : ");
     var first = true;
     var isValueType = gp.HasNotNullableValueTypeConstraint;
-    var isUnmanaged = isValueType && gp.IsUnmanaged();
+    var isUnmanaged = isValueType && gp.IsUnmanaged;
     if (gp.HasReferenceTypeConstraint) {
       sb.Append("class");
       first = false;
@@ -798,7 +798,7 @@ public class CSharpFormatter : CodeFormatter {
       }
     }
     sb.Append(' ', indent).Append(this.Attributes(md));
-    if (md.IsReadOnly()) {
+    if (md.IsReadOnly) {
       sb.Append("readonly ");
     }
     var methodName = this.MethodName(md, out var returnTypeName);
@@ -1167,7 +1167,7 @@ public class CSharpFormatter : CodeFormatter {
   private string Parameter(ParameterDefinition pd) {
     var sb = new StringBuilder();
     sb.Append(this.CustomAttributesInline(pd));
-    if (pd.IsScopedRef()) {
+    if (pd.IsScopedRef) {
       sb.Append("scoped ");
     }
     if (pd.IsIn) {
@@ -1176,7 +1176,7 @@ public class CSharpFormatter : CodeFormatter {
     if (pd.IsOut) {
       sb.Append("out ");
     }
-    if (pd.IsParamArray()) {
+    if (pd.IsParamArray) {
       sb.Append("params ");
     }
     sb.Append(this.TypeName(pd.ParameterType, pd)).Append(' ').Append(pd.Name);
@@ -1201,7 +1201,7 @@ public class CSharpFormatter : CodeFormatter {
     sb.Append('(');
     if (md.HasParameters) {
       // Detect extension methods
-      if (md.IsMarkedAsExtension()) {
+      if (md.IsMarkedAsExtension) {
         sb.Append("this ");
       }
       sb.AppendJoin(", ", md.Parameters.Select(this.Parameter));
@@ -1228,7 +1228,7 @@ public class CSharpFormatter : CodeFormatter {
     {
       var sb = new StringBuilder();
       sb.Append(' ', indent);
-      if (pd.IsRequired()) {
+      if (pd.IsRequired) {
         sb.Append("required ");
       }
       sb.Append(this.TypeName(pd.PropertyType, pd)).Append(' ');
@@ -1263,7 +1263,7 @@ public class CSharpFormatter : CodeFormatter {
     }
     var sb = new StringBuilder();
     sb.Append(' ', indent).Append(this.Attributes(method));
-    if (method.IsReadOnly()) {
+    if (method.IsReadOnly) {
       sb.Append("readonly ");
     }
     if (method.IsGetter) {
@@ -1361,10 +1361,10 @@ public class CSharpFormatter : CodeFormatter {
       sb.Append("interface");
     }
     else if (td.IsValueType) {
-      if (td.IsReadOnly()) {
+      if (td.IsReadOnly) {
         sb.Append("readonly ");
       }
-      if (td.IsByRefLike()) {
+      if (td.IsByRefLike) {
         sb.Append("ref ");
       }
       sb.Append("struct");
@@ -1484,7 +1484,7 @@ public class CSharpFormatter : CodeFormatter {
     if (tr is ByReferenceType brt) { // => ref T
       // omit the "ref" for "out" parameters - it's covered by the "out"
       if (context is not ParameterDefinition { IsOut: true }) {
-        prefix = context.IsReadOnly() ? "ref readonly " : "ref ";
+        prefix = context.IsReadOnly ? "ref readonly " : "ref ";
       }
       tr = brt.ElementType;
     }
@@ -1581,7 +1581,7 @@ public class CSharpFormatter : CodeFormatter {
         ++tnc.NullableIndex;
       }
     }
-    else if (!tr.IsVoid()) {
+    else if (!tr.IsVoid) {
       nullability = tnc.Main?.GetNullability(tnc.Method, tnc.Type, tnc.NullableIndex++);
     }
     // Check for System.Nullable<T> and make it T?

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -424,8 +424,7 @@ public class CSharpFormatter : CodeFormatter {
           if (isUnmanaged) {
             // Expectation: First constraint is on ValueType modified by UnmanagedType; if so, write that as "unmanaged"
             // Note that UnmanagedType is neither a core library type nor a locally synthesized one.
-            if (ct is RequiredModifierType rmt && rmt.ElementType.IsNamed("System", "ValueType") &&
-                rmt.ModifierType.IsNamed("System.Runtime.InteropServices", "UnmanagedType")) {
+            if (ct.IsModifiedType("System", "ValueType", "System.Runtime.InteropServices", "UnmanagedType")) {
               sb.Append(this.CustomAttributesInline(gpc)).Append("unmanaged");
               first = false;
               isValueType = false;
@@ -1272,8 +1271,7 @@ public class CSharpFormatter : CodeFormatter {
     else if (method.IsSetter) {
       // For `init`, it's not an attribute on the setter method, but rather a "required modifier" on its return type (void).
       // A bit weird, but whatever.
-      if (method.ReturnType is RequiredModifierType rmt && rmt.ElementType == rmt.Module.TypeSystem.Void &&
-          rmt.ModifierType.IsNamed("System.Runtime.CompilerServices", "IsExternalInit")) {
+      if (method.ReturnType.IsModifiedType(method.Module.TypeSystem.Void, "System.Runtime.CompilerServices", "IsExternalInit")) {
         sb.Append("init");
       }
       else {

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -1201,13 +1201,8 @@ public class CSharpFormatter : CodeFormatter {
     sb.Append('(');
     if (md.HasParameters) {
       // Detect extension methods
-      if (md.HasCustomAttributes) {
-        foreach (var ca in md.CustomAttributes) {
-          if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "ExtensionAttribute")) {
-            sb.Append("this ");
-            break;
-          }
-        }
+      if (md.IsMarkedAsExtension()) {
+        sb.Append("this ");
       }
       sb.AppendJoin(", ", md.Parameters.Select(this.Parameter));
     }

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -8,347 +8,383 @@ using Mono.Cecil;
 
 namespace Zastai.Build.ApiReference;
 
-/// <summary>Utility methods for working with Mono.Cecil elements.</summary>
+/// <summary>Utility methods for working with <c>Mono.Cecil</c> elements.</summary>
 internal static class CecilUtils {
 
-  public static Nullability? GetNullability(this ICustomAttributeProvider cap, MethodDefinition? context, int idx = 0)
-    => cap.GetNullability(idx) ?? context.GetNullabilityContext();
+  extension(AssemblyDefinition ad) {
 
-  public static Nullability? GetNullability(this ICustomAttributeProvider cap, MethodDefinition? methodContext,
-                                            TypeDefinition? typeContext, int idx = 0)
-    => cap.GetNullability(idx) ?? methodContext.GetNullabilityContext() ?? typeContext.GetNullabilityContext();
-
-  public static Nullability? GetNullability(this ICustomAttributeProvider cap, TypeDefinition? context, int idx = 0)
-    => cap.GetNullability(idx) ?? context.GetNullabilityContext();
-
-  public static Nullability? GetNullability(this ICustomAttributeProvider cap, int idx = 0) {
-    if (cap.HasCustomAttributes) {
-      foreach (var ca in cap.CustomAttributes) {
-        if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "NullableAttribute")) {
-          if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
-            var arg = ca.ConstructorArguments[0];
-            if (arg.Value is CustomAttributeArgument[] values) {
-              if (values.Length > idx) {
-                arg = values[idx];
-              }
-              else {
-                // There is a array of values but not for this index: should really be an error, but assume null-oblivious.
-                return Nullability.Oblivious;
-              }
-            }
-            if (arg.Type == arg.Type.Module.TypeSystem.Byte && arg.Value is byte b) {
-              return (Nullability) b;
-            }
-          }
-          // Attribute present: assume null-oblivious when we can't get a definite value
-          return Nullability.Oblivious;
-        }
+    public HashSet<string> GetRuntimeFeatures() {
+      var coreLib = ad.MainModule.TypeSystem.CoreLibrary;
+      // FIXME: What this _should_ do is look up System.Runtime.CompilerServices.RuntimeFeature (in the context of coreLib), and
+      //        enumerate all its fields, returning a set containing the names of any that are string constants.
+      //        However, I have not been able to get that initial type lookup to work, and we currently only care about numeric
+      //        IntPtr support, so we just check for .NET 7 or later.
+      if (coreLib is AssemblyNameReference { Name: "System.Runtime" } anr && anr.Version >= Version.Parse("7.0")) {
+        return ["NumericIntPtr"];
       }
+      return [];
     }
-    // No attribute: unknown - context needed
-    return null;
+
   }
 
-  private static Nullability? GetNullabilityContext(this MethodDefinition? md) {
-    if (md is not null) {
-      var nullability = md.GetNullabilityContextInternal();
-      if (nullability.HasValue) {
-        return nullability;
-      }
-      // No attribute: get from parent context (i.e. enclosing type).
-      return md.DeclaringType.GetNullabilityContext();
-    }
-    return null;
+  extension(EventDefinition ed) {
+
+    // FIXME: Can the remove method differ? Does it matter?
+    public bool IsInternalApi() => ed.AddMethod.IsInternalApi();
+
+    // FIXME: Can the remove method differ? Does it matter?
+    public bool IsPublicApi() => ed.AddMethod.IsPublicApi();
+
   }
 
-  private static Nullability? GetNullabilityContext(this TypeDefinition? td) {
-    while (td is not null) {
-      var nullability = td.GetNullabilityContextInternal();
-      if (nullability.HasValue) {
-        return nullability;
-      }
-      // No attribute: get from parent context (i.e. enclosing type).
-      td = td.DeclaringType;
-    }
-    return null;
-  }
+  extension(FieldDefinition fd) {
 
-  private static Nullability? GetNullabilityContextInternal(this ICustomAttributeProvider? cap) {
-    if (cap is not null && cap.HasCustomAttributes) {
-      foreach (var ca in cap.CustomAttributes) {
-        if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "NullableContextAttribute")) {
-          if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
-            var arg = ca.ConstructorArguments[0];
-            if (arg.Type == arg.Type.Module.TypeSystem.Byte && arg.Value is byte b) {
-              return (Nullability) b;
-            }
-          }
-          // Attribute present: assume 0 when we can't get a definite value
-          return Nullability.Oblivious;
-        }
-      }
-    }
-    // No attribute: unknown - check parent context
-    return null;
-  }
-
-  public static HashSet<string> GetRuntimeFeatures(this AssemblyDefinition ad) {
-    var coreLib = ad.MainModule.TypeSystem.CoreLibrary;
-    // FIXME: What this _should_ do is look up System.Runtime.CompilerServices.RuntimeFeature (in the context of coreLib), and
-    //        enumerate all its fields, returning a set containing the names of any that are string constants.
-    //        However, I have not been able to get that initial type lookup to work, and we currently only care about numeric IntPtr
-    //        support, so we just check for .NET 7 or later.
-    if (coreLib is AssemblyNameReference { Name: "System.Runtime" } anr && anr.Version >= Version.Parse("7.0")) {
-      return ["NumericIntPtr"];
-    }
-    return [];
-  }
-
-  public static string?[]? GetTupleElementNames(this ICustomAttributeProvider? cap) {
-    if (cap is not null && cap.HasCustomAttributes) {
-      foreach (var ca in cap.CustomAttributes) {
-        if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "TupleElementNamesAttribute")) {
-          if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
-            var arg = ca.ConstructorArguments[0];
-            if (arg.Value is CustomAttributeArgument[] values) {
-              var names = new string?[values.Length];
-              var idx = 0;
-              foreach (var value in values) {
-                if (value.Type == value.Type.Module.TypeSystem.String && value.Value is string name) {
-                  names[idx] = name;
+    public bool IsDecimalConstant(out decimal? value) {
+      if (fd is { IsStatic: true, IsInitOnly: true, HasCustomAttributes: true }) {
+        foreach (var ca in fd.CustomAttributes) {
+          if (ca.AttributeType.FullName == "System.Runtime.CompilerServices.DecimalConstantAttribute") {
+            var valid = false;
+            byte scale = 0;
+            var negative = false;
+            var lo = 0;
+            var mid = 0;
+            var hi = 0;
+            if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 5) {
+              var ts = fd.Module.TypeSystem;
+              // 2 forms: one has int for lo/mid/hi, the other has uint
+              if (ca.ConstructorArguments[0].Type == ts.Byte) {
+                scale = (byte) ca.ConstructorArguments[0].Value;
+                if (ca.ConstructorArguments[1].Type == ts.Byte) {
+                  negative = 0 != (byte) ca.ConstructorArguments[1].Value;
+                  if (ca.ConstructorArguments[2].Type == ts.Int32) {
+                    hi = (int) ca.ConstructorArguments[2].Value;
+                    if (ca.ConstructorArguments[3].Type == ts.Int32) {
+                      mid = (int) ca.ConstructorArguments[3].Value;
+                      if (ca.ConstructorArguments[4].Type == ts.Int32) {
+                        lo = (int) ca.ConstructorArguments[4].Value;
+                        valid = true;
+                      }
+                    }
+                  }
+                  else if (ca.ConstructorArguments[2].Type == ts.UInt32) {
+                    hi = (int) (uint) ca.ConstructorArguments[2].Value;
+                    if (ca.ConstructorArguments[3].Type == ts.UInt32) {
+                      mid = (int) (uint) ca.ConstructorArguments[3].Value;
+                      if (ca.ConstructorArguments[4].Type == ts.UInt32) {
+                        lo = (int) (uint) ca.ConstructorArguments[4].Value;
+                        valid = true;
+                      }
+                    }
+                  }
                 }
-                ++idx;
               }
-              return names;
             }
+            value = valid ? new decimal(lo, mid, hi, negative, scale) : null;
+            return true;
           }
-          return null;
         }
       }
+      value = null;
+      return false;
     }
-    return null;
+
+    public bool IsInternalApi() => fd.IsAssembly || fd.IsFamilyAndAssembly;
+
+    public bool IsPublicApi() => fd.IsPublic || fd.IsFamily || fd.IsFamilyOrAssembly;
+
   }
 
-  public static bool HasAttribute(this ICustomAttributeProvider? cap, string ns, string name)
-    => cap is not null && cap.HasCustomAttributes && cap.CustomAttributes.Any(ca => ca.AttributeType.IsNamed(ns, name));
+  extension(GenericParameter? gp) {
 
-  public static bool HasCovariantReturn(this MethodDefinition md)
-    => md.HasAttribute("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute");
+    public bool IsUnmanaged() => gp.HasAttribute("System.Runtime.CompilerServices", "IsUnmanagedAttribute");
 
-  public static MethodDefinition? IfPublicApi(this MethodDefinition? method) {
-    if (method is null) {
+  }
+
+  extension(ICustomAttributeProvider? cap) {
+
+    public Nullability? GetNullability(MethodDefinition? context, int idx = 0)
+      => cap?.GetNullability(idx) ?? context.GetNullabilityContext();
+
+    public Nullability? GetNullability(MethodDefinition? methodContext,
+                                       TypeDefinition? typeContext, int idx = 0)
+      => cap?.GetNullability(idx) ?? methodContext.GetNullabilityContext() ?? typeContext.GetNullabilityContext();
+
+    public Nullability? GetNullability(TypeDefinition? context, int idx = 0)
+      => cap?.GetNullability(idx) ?? context.GetNullabilityContext();
+
+    public Nullability? GetNullability(int idx = 0) {
+      if (cap is not null && cap.HasCustomAttributes) {
+        foreach (var ca in cap.CustomAttributes) {
+          if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "NullableAttribute")) {
+            if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
+              var arg = ca.ConstructorArguments[0];
+              if (arg.Value is CustomAttributeArgument[] values) {
+                if (values.Length > idx) {
+                  arg = values[idx];
+                }
+                else {
+                  // There is a array of values but not for this index: should really be an error, but assume null-oblivious.
+                  return Nullability.Oblivious;
+                }
+              }
+              if (arg.Type == arg.Type.Module.TypeSystem.Byte && arg.Value is byte b) {
+                return (Nullability) b;
+              }
+            }
+            // Attribute present: assume null-oblivious when we can't get a definite value
+            return Nullability.Oblivious;
+          }
+        }
+      }
+      // No attribute: unknown - context needed
       return null;
     }
-    return method.IsPublicApi() ? method : null;
-  }
 
-  public static bool IsByRefLike(this TypeDefinition td)
-    => td.HasAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute");
-
-  private static bool IsCompilerGenerated(this TypeDefinition? td)
-    => td is not null && td.HasAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
-
-  public static bool IsCompilerGenerated(this TypeReference tr) => tr.Resolve().IsCompilerGenerated();
-
-  public static bool IsCoreLibraryType(this TypeReference tr) => tr.Scope == tr.Module.TypeSystem.CoreLibrary;
-
-  public static bool IsCoreLibraryType(this TypeReference tr, string? ns) => tr.IsCoreLibraryType() && tr.IsNamed(ns);
-
-  public static bool IsCoreLibraryType(this TypeReference tr, string? ns, string name)
-    => tr.IsCoreLibraryType() && tr.IsNamed(ns, name);
-
-  public static bool IsDecimalConstant(this FieldDefinition fd, out decimal? value) {
-    if (fd is { IsStatic: true, IsInitOnly: true, HasCustomAttributes: true }) {
-      foreach (var ca in fd.CustomAttributes) {
-        if (ca.AttributeType.FullName == "System.Runtime.CompilerServices.DecimalConstantAttribute") {
-          var valid = false;
-          byte scale = 0;
-          var negative = false;
-          var lo = 0;
-          var mid = 0;
-          var hi = 0;
-          if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 5) {
-            var ts = fd.Module.TypeSystem;
-            // 2 forms: one has int for lo/mid/hi, the other has uint
-            if (ca.ConstructorArguments[0].Type == ts.Byte) {
-              scale = (byte) ca.ConstructorArguments[0].Value;
-              if (ca.ConstructorArguments[1].Type == ts.Byte) {
-                negative = 0 != (byte) ca.ConstructorArguments[1].Value;
-                if (ca.ConstructorArguments[2].Type == ts.Int32) {
-                  hi = (int) ca.ConstructorArguments[2].Value;
-                  if (ca.ConstructorArguments[3].Type == ts.Int32) {
-                    mid = (int) ca.ConstructorArguments[3].Value;
-                    if (ca.ConstructorArguments[4].Type == ts.Int32) {
-                      lo = (int) ca.ConstructorArguments[4].Value;
-                      valid = true;
-                    }
-                  }
-                }
-                else if (ca.ConstructorArguments[2].Type == ts.UInt32) {
-                  hi = (int) (uint) ca.ConstructorArguments[2].Value;
-                  if (ca.ConstructorArguments[3].Type == ts.UInt32) {
-                    mid = (int) (uint) ca.ConstructorArguments[3].Value;
-                    if (ca.ConstructorArguments[4].Type == ts.UInt32) {
-                      lo = (int) (uint) ca.ConstructorArguments[4].Value;
-                      valid = true;
-                    }
-                  }
-                }
+    private Nullability? GetNullabilityContextInternal() {
+      if (cap is not null && cap.HasCustomAttributes) {
+        foreach (var ca in cap.CustomAttributes) {
+          if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "NullableContextAttribute")) {
+            if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
+              var arg = ca.ConstructorArguments[0];
+              if (arg.Type == arg.Type.Module.TypeSystem.Byte && arg.Value is byte b) {
+                return (Nullability) b;
               }
             }
+            // Attribute present: assume 0 when we can't get a definite value
+            return Nullability.Oblivious;
           }
-          value = valid ? new decimal(lo, mid, hi, negative, scale) : null;
+        }
+      }
+      // No attribute: unknown - check parent context
+      return null;
+    }
+
+    public string?[]? GetTupleElementNames() {
+      if (cap is not null && cap.HasCustomAttributes) {
+        foreach (var ca in cap.CustomAttributes) {
+          if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "TupleElementNamesAttribute")) {
+            if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
+              var arg = ca.ConstructorArguments[0];
+              if (arg.Value is CustomAttributeArgument[] values) {
+                var names = new string?[values.Length];
+                var idx = 0;
+                foreach (var value in values) {
+                  if (value.Type == value.Type.Module.TypeSystem.String && value.Value is string name) {
+                    names[idx] = name;
+                  }
+                  ++idx;
+                }
+                return names;
+              }
+            }
+            return null;
+          }
+        }
+      }
+      return null;
+    }
+
+    public bool HasAttribute(string ns, string name)
+      => cap is not null && cap.HasCustomAttributes && cap.CustomAttributes.Any(ca => ca.AttributeType.IsNamed(ns, name));
+
+    public bool IsDynamic(int idx) {
+      if (cap is not null && cap.HasCustomAttributes) {
+        foreach (var ca in cap.CustomAttributes) {
+          if (ca.AttributeType.FullName == "System.Runtime.CompilerServices.DynamicAttribute") {
+            if (idx == 0 && !ca.HasConstructorArguments) {
+              return true;
+            }
+            if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
+              var arg = ca.ConstructorArguments[0];
+              if (arg.Value is CustomAttributeArgument[] values && values.Length > idx) {
+                arg = values[idx];
+              }
+              else if (idx != 0) {
+                return false;
+              }
+              return arg.Type == arg.Type.Module.TypeSystem.Boolean && arg.Value is true;
+            }
+            return false;
+          }
+        }
+      }
+      return false;
+    }
+
+    public bool IsMarkedAsExtension() => cap.HasAttribute("System.Runtime.CompilerServices", "ExtensionAttribute");
+
+    public bool IsNativeInteger(int idx) {
+      if (cap is not null && cap.HasCustomAttributes) {
+        foreach (var ca in cap.CustomAttributes) {
+          if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "NativeIntegerAttribute")) {
+            if (idx == 0 && !ca.HasConstructorArguments) {
+              return true;
+            }
+            if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
+              var arg = ca.ConstructorArguments[0];
+              if (arg.Value is CustomAttributeArgument[] values && values.Length > idx) {
+                arg = values[idx];
+              }
+              else if (idx != 0) {
+                return false;
+              }
+              return arg.Type == arg.Type.Module.TypeSystem.Boolean && arg.Value is true;
+            }
+            return false;
+          }
+        }
+      }
+      return false;
+    }
+
+    public bool IsReadOnly() => cap.HasAttribute("System.Runtime.CompilerServices", "IsReadOnlyAttribute");
+
+  }
+
+  extension(IMemberDefinition? md) {
+
+    public bool IsRequired() => md.HasAttribute("System.Runtime.CompilerServices", "RequiredMemberAttribute");
+
+  }
+
+  extension(MethodDefinition? md) {
+
+    private Nullability? GetNullabilityContext() {
+      if (md is not null) {
+        var nullability = md.GetNullabilityContextInternal();
+        if (nullability.HasValue) {
+          return nullability;
+        }
+        // No attribute: get from parent context (i.e. enclosing type).
+        return md.DeclaringType.GetNullabilityContext();
+      }
+      return null;
+    }
+
+    public bool HasCovariantReturn() => md.HasAttribute("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute");
+
+    public MethodDefinition? IfPublicApi() {
+      if (md is null) {
+        return null;
+      }
+      return md.IsPublicApi() ? md : null;
+    }
+
+    public bool IsInternalApi() => md is not null && (md.IsAssembly || md.IsFamilyAndAssembly);
+
+    public bool IsPublicApi() => md is not null && (md.IsPublic || md.IsFamily || md.IsFamilyOrAssembly);
+
+  }
+
+  extension(ParameterDefinition? pd) {
+
+    public bool IsParamArray() => pd.HasAttribute("System", "ParamArrayAttribute");
+
+    public bool IsScopedRef() => pd.HasAttribute("System.Runtime.CompilerServices", "ScopedRefAttribute");
+
+  }
+
+  extension(TypeDefinition? td) {
+
+    private Nullability? GetNullabilityContext() {
+      while (td is not null) {
+        var nullability = td.GetNullabilityContextInternal();
+        if (nullability.HasValue) {
+          return nullability;
+        }
+        // No attribute: get from parent context (i.e. enclosing type).
+        td = td.DeclaringType;
+      }
+      return null;
+    }
+
+    public bool IsByRefLike()
+      => td.HasAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute");
+
+    private bool IsCompilerGenerated()
+      => td is not null && td.HasAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
+
+    public bool IsDelegate([NotNullWhen(true)] out MethodDefinition? invoke) {
+      invoke = null;
+      if (td is null) {
+        return false;
+      }
+      // They have no contents other than methods.
+      if (td.HasEvents || td.HasFields || td.HasInterfaces || !td.HasMethods || td.HasNestedTypes || td.HasProperties) {
+        return false;
+      }
+      // Base is always System.MulticastDelegate
+      if (td.BaseType is null || !td.BaseType.IsCoreLibraryType(nameof(System), nameof(MulticastDelegate))) {
+        return false;
+      }
+      // Further checks that _could_ be added, if it turns out there's cases where built assemblies contain subclasses of
+      // MulticastDelegate that are not actually delegate types:
+      // - class size seems to always be -1
+      // - class attributes are sealed + visibility
+      // - exactly 4 methods:
+      //   - constructor with 2 arguments: an object called "object" and a nint/IntPtr called "method"
+      //   - Invoke() with the delegate's signature (return type and arguments)
+      //   - BeginInvoke() taking the in/ref/out arguments of Invoke() plus an AsyncCallback called "callback" and an object called
+      //     "object"; returns IAsyncResult.
+      //   - EndInvoke() returning Invoke()'s return type and taking its ref/out arguments plus an IAsyncResult called "result".
+      //   - fixed attributes: Public+HideBySig+SpecialName+RTSpecialName for the constructor;
+      //                       Public+MethodAttributes.Virtual+MethodAttributes.HideBySig+MethodAttributes.NewSlot for the others
+      invoke = td.Methods.FirstOrDefault(md => md.Name == "Invoke");
+      return invoke is not null;
+    }
+
+    public bool IsExtensionBlock()
+      => td is not null && (td.IsSpecialName && td.IsMarkedAsExtension() && td.Name.StartsWith("<G>"));
+
+    public bool IsInternalApi() => td is not null && (td.IsNestedAssembly || td.IsNestedFamilyAndAssembly || td.IsNotPublic);
+
+    public bool IsPublicApi()
+      => td is not null && (td.IsPublic || td.IsNestedPublic || td.IsNestedFamily || td.IsNestedFamilyOrAssembly);
+
+  }
+
+  extension(TypeReference tr) {
+
+    public bool IsCompilerGenerated() => tr.Resolve().IsCompilerGenerated();
+
+    public bool IsCoreLibraryType() => tr.Scope == tr.Module.TypeSystem.CoreLibrary;
+
+    public bool IsCoreLibraryType(string? ns) => tr.IsCoreLibraryType() && tr.IsNamed(ns);
+
+    public bool IsCoreLibraryType(string? ns, string name) => tr.IsCoreLibraryType() && tr.IsNamed(ns, name);
+
+    public bool IsLocalType() => tr.Scope == tr.Module;
+
+    public bool IsLocalType(string? ns) => tr.IsLocalType() && tr.IsNamed(ns);
+
+    public bool IsLocalType(string? ns, string name) => tr.IsLocalType() && tr.IsNamed(ns, name);
+
+    public bool IsNamed(string? ns) => tr.Namespace == ns;
+
+    public bool IsNamed(string? ns, string name) => tr.Namespace == ns && tr.Name == name;
+
+    public bool IsVoid() => tr == tr.Module.TypeSystem.Void;
+
+    public string NonGenericName() {
+      var name = tr.Name;
+      var backTick = name.IndexOf('`');
+      return backTick >= 0 ? name.Substring(0, backTick) : name;
+    }
+
+    public bool TryUnwrapNullable([NotNullWhen(true)] out TypeReference? unwrapped) {
+      if (tr.Scope == tr.Module.TypeSystem.CoreLibrary) {
+        if (tr is { IsGenericInstance: true, Namespace: "System", Name: "Nullable`1" }) {
+          var gi = (IGenericInstance) tr;
+          Trace.Assert(gi.HasGenericArguments && gi.GenericArguments.Count == 1,
+                       "Nullable type instance does not have exactly one generic argument.");
+          unwrapped = gi.GenericArguments[0];
           return true;
         }
       }
-    }
-    value = null;
-    return false;
-  }
-
-  public static bool IsDelegate(this TypeDefinition td, [NotNullWhen(true)] out MethodDefinition? invoke) {
-    invoke = null;
-    // They have no contents other than methods.
-    if (td.HasEvents || td.HasFields || td.HasInterfaces || !td.HasMethods || td.HasNestedTypes || td.HasProperties) {
+      unwrapped = null;
       return false;
     }
-    // Base is always System.MulticastDelegate
-    if (td.BaseType is null || !td.BaseType.IsCoreLibraryType(nameof(System), nameof(MulticastDelegate))) {
-      return false;
-    }
-    // Further checks that _could_ be added, if it turns out there's cases where built assemblies contain subclasses of
-    // MulticastDelegate that are not actually delegate types:
-    // - class size seems to always be -1
-    // - class attributes are sealed + visibility
-    // - exactly 4 methods:
-    //   - constructor with 2 arguments: an object called "object" and a nint/IntPtr called "method"
-    //   - Invoke() with the delegate's signature (return type and arguments)
-    //   - BeginInvoke() taking the in/ref/out arguments of Invoke() plus an AsyncCallback called "callback" and an object called
-    //     "object"; returns IAsyncResult.
-    //   - EndInvoke() returning Invoke()'s return type and taking its ref/out arguments plus an IAsyncResult called "result".
-    //   - fixed attributes: Public+HideBySig+SpecialName+RTSpecialName for the constructor;
-    //                       Public+MethodAttributes.Virtual+MethodAttributes.HideBySig+MethodAttributes.NewSlot for the others
-    invoke = td.Methods.FirstOrDefault(md => md.Name == "Invoke");
-    return invoke is not null;
-  }
 
-  public static bool IsDynamic(this ICustomAttributeProvider? cap, int idx) {
-    if (cap is not null && cap.HasCustomAttributes) {
-      foreach (var ca in cap.CustomAttributes) {
-        if (ca.AttributeType.FullName == "System.Runtime.CompilerServices.DynamicAttribute") {
-          if (idx == 0 && !ca.HasConstructorArguments) {
-            return true;
-          }
-          if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
-            var arg = ca.ConstructorArguments[0];
-            if (arg.Value is CustomAttributeArgument[] values && values.Length > idx) {
-              arg = values[idx];
-            }
-            else if (idx != 0) {
-              return false;
-            }
-            return arg.Type == arg.Type.Module.TypeSystem.Boolean && arg.Value is true;
-          }
-          return false;
-        }
-      }
-    }
-    return false;
-  }
-
-  public static bool IsExtensionBlock(this TypeDefinition td)
-    => td.IsSpecialName && td.IsMarkedAsExtension() && td.Name.StartsWith("<G>");
-
-  // FIXME: Can the remove method differ? Does it matter?
-  public static bool IsInternalApi(this EventDefinition ed) => ed.AddMethod.IsInternalApi();
-
-  public static bool IsInternalApi(this FieldDefinition fd) => fd.IsAssembly || fd.IsFamilyAndAssembly;
-
-  public static bool IsInternalApi(this MethodDefinition md) => md.IsAssembly || md.IsFamilyAndAssembly;
-
-  public static bool IsInternalApi(this TypeDefinition td) => td.IsNestedAssembly || td.IsNestedFamilyAndAssembly || td.IsNotPublic;
-
-  public static bool IsLocalType(this TypeReference tr) => tr.Scope == tr.Module;
-
-  public static bool IsLocalType(this TypeReference tr, string? ns) => tr.IsLocalType() && tr.IsNamed(ns);
-
-  public static bool IsLocalType(this TypeReference tr, string? ns, string name) => tr.IsLocalType() && tr.IsNamed(ns, name);
-
-  public static bool IsMarkedAsExtension(this ICustomAttributeProvider cap)
-    => cap.HasAttribute("System.Runtime.CompilerServices", "ExtensionAttribute");
-
-  public static bool IsNamed(this TypeReference tr, string? ns) => tr.Namespace == ns;
-
-  public static bool IsNamed(this TypeReference tr, string? ns, string name) => tr.Namespace == ns && tr.Name == name;
-
-  public static bool IsNativeInteger(this ICustomAttributeProvider? cap, int idx) {
-    if (cap is not null && cap.HasCustomAttributes) {
-      foreach (var ca in cap.CustomAttributes) {
-        if (ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "NativeIntegerAttribute")) {
-          if (idx == 0 && !ca.HasConstructorArguments) {
-            return true;
-          }
-          if (ca.HasConstructorArguments && ca.ConstructorArguments.Count == 1) {
-            var arg = ca.ConstructorArguments[0];
-            if (arg.Value is CustomAttributeArgument[] values && values.Length > idx) {
-              arg = values[idx];
-            }
-            else if (idx != 0) {
-              return false;
-            }
-            return arg.Type == arg.Type.Module.TypeSystem.Boolean && arg.Value is true;
-          }
-          return false;
-        }
-      }
-    }
-    return false;
-  }
-
-  public static bool IsParamArray(this ParameterDefinition pd) => pd.HasAttribute("System", "ParamArrayAttribute");
-
-  // FIXME: Can the remove method differ? Does it matter?
-  public static bool IsPublicApi(this EventDefinition ed) => ed.AddMethod.IsPublicApi();
-
-  public static bool IsPublicApi(this FieldDefinition fd) => fd.IsPublic || fd.IsFamily || fd.IsFamilyOrAssembly;
-
-  public static bool IsPublicApi(this MethodDefinition md) => md.IsPublic || md.IsFamily || md.IsFamilyOrAssembly;
-
-  public static bool IsPublicApi(this TypeDefinition td)
-    => td.IsPublic || td.IsNestedPublic || td.IsNestedFamily || td.IsNestedFamilyOrAssembly;
-
-  public static bool IsReadOnly(this ICustomAttributeProvider? provider)
-    => provider.HasAttribute("System.Runtime.CompilerServices", "IsReadOnlyAttribute");
-
-  public static bool IsRequired(this IMemberDefinition? md)
-    => md.HasAttribute("System.Runtime.CompilerServices", "RequiredMemberAttribute");
-
-  public static bool IsScopedRef(this ParameterDefinition? pd)
-    => pd.HasAttribute("System.Runtime.CompilerServices", "ScopedRefAttribute");
-
-  public static bool IsUnmanaged(this GenericParameter? gp)
-    => gp.HasAttribute("System.Runtime.CompilerServices", "IsUnmanagedAttribute");
-
-  public static bool IsVoid(this TypeReference tr) => tr == tr.Module.TypeSystem.Void;
-
-  public static string NonGenericName(this TypeReference tr) {
-    var name = tr.Name;
-    var backTick = name.IndexOf('`');
-    return backTick >= 0 ? name.Substring(0, backTick) : name;
-  }
-
-  public static bool TryUnwrapNullable(this TypeReference tr, [NotNullWhen(true)] out TypeReference? unwrapped) {
-    if (tr.Scope == tr.Module.TypeSystem.CoreLibrary) {
-      if (tr is { IsGenericInstance: true, Namespace: "System", Name: "Nullable`1" }) {
-        var gi = (IGenericInstance) tr;
-        Trace.Assert(gi.HasGenericArguments && gi.GenericArguments.Count == 1,
-                     "Nullable type instance does not have exactly one generic argument.");
-        unwrapped = gi.GenericArguments[0];
-        return true;
-      }
-    }
-    unwrapped = null;
-    return false;
   }
 
 }

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -354,6 +354,12 @@ internal static class CecilUtils {
 
     public bool IsLocalType(string? ns, string name) => tr.IsLocalType() && tr.IsNamed(ns, name);
 
+    public bool IsModifiedType(TypeReference elementType, string? ns, string modifier)
+      => tr is RequiredModifierType rmt && rmt.ElementType == elementType && rmt.ModifierType.IsNamed(ns, modifier);
+
+    public bool IsModifiedType(string? ns1, string element, string? ns2, string modifier)
+      => tr is RequiredModifierType rmt && rmt.ElementType.IsNamed(ns1, element) && rmt.ModifierType.IsNamed(ns2, modifier);
+
     public bool IsNamed(string? ns) => tr.Namespace == ns;
 
     public bool IsNamed(string? ns, string name) => tr.Namespace == ns && tr.Name == name;

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -186,6 +186,8 @@ internal static class CecilUtils {
     public bool HasAttribute(string ns, string name)
       => cap is not null && cap.HasCustomAttributes && cap.CustomAttributes.Any(ca => ca.AttributeType.IsNamed(ns, name));
 
+    public bool IsCompilerGenerated => cap.HasAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
+
     public bool IsDynamic(int idx) {
       if (cap is not null && cap.HasCustomAttributes) {
         foreach (var ca in cap.CustomAttributes) {
@@ -294,8 +296,6 @@ internal static class CecilUtils {
 
     public bool IsByRefLike => td.HasAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute");
 
-    private bool IsCompilerGenerated => td.HasAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
-
     public bool IsDelegate([NotNullWhen(true)] out MethodDefinition? invoke) {
       invoke = null;
       if (td is null) {
@@ -336,11 +336,7 @@ internal static class CecilUtils {
 
   extension(TypeReference tr) {
 
-    public bool IsCompilerGenerated {
-      get {
-        return tr.Resolve().IsCompilerGenerated;
-      }
-    }
+    public bool IsCompilerGenerated => ((ICustomAttributeProvider) tr.Resolve()).IsCompilerGenerated;
 
     public bool IsCoreLibraryType() => tr.Scope == tr.Module.TypeSystem.CoreLibrary;
 

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -129,9 +129,11 @@ internal static class CecilUtils {
     return null;
   }
 
+  public static bool HasAttribute(this ICustomAttributeProvider? cap, string ns, string name)
+    => cap is not null && cap.HasCustomAttributes && cap.CustomAttributes.Any(ca => ca.AttributeType.IsNamed(ns, name));
+
   public static bool HasCovariantReturn(this MethodDefinition md)
-    => md.HasCustomAttributes &&
-       md.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute"));
+    => md.HasAttribute("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute");
 
   public static MethodDefinition? IfPublicApi(this MethodDefinition? method) {
     if (method is null) {
@@ -141,12 +143,10 @@ internal static class CecilUtils {
   }
 
   public static bool IsByRefLike(this TypeDefinition td)
-    => td.HasCustomAttributes &&
-       td.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "IsByRefLikeAttribute"));
+    => td.HasAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute");
 
   private static bool IsCompilerGenerated(this TypeDefinition? td)
-    => td is not null && td.HasCustomAttributes &&
-       td.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"));
+    => td is not null && td.HasAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
 
   public static bool IsCompilerGenerated(this TypeReference tr) => tr.Resolve().IsCompilerGenerated();
 
@@ -256,6 +256,9 @@ internal static class CecilUtils {
     return false;
   }
 
+  public static bool IsExtensionBlock(this TypeDefinition td)
+    => td.IsSpecialName && td.IsMarkedAsExtension() && td.Name.StartsWith("<G>");
+
   // FIXME: Can the remove method differ? Does it matter?
   public static bool IsInternalApi(this EventDefinition ed) => ed.AddMethod.IsInternalApi();
 
@@ -270,6 +273,9 @@ internal static class CecilUtils {
   public static bool IsLocalType(this TypeReference tr, string? ns) => tr.IsLocalType() && tr.IsNamed(ns);
 
   public static bool IsLocalType(this TypeReference tr, string? ns, string name) => tr.IsLocalType() && tr.IsNamed(ns, name);
+
+  public static bool IsMarkedAsExtension(this ICustomAttributeProvider cap)
+    => cap.HasAttribute("System.Runtime.CompilerServices", "ExtensionAttribute");
 
   public static bool IsNamed(this TypeReference tr, string? ns) => tr.Namespace == ns;
 
@@ -299,8 +305,7 @@ internal static class CecilUtils {
     return false;
   }
 
-  public static bool IsParamArray(this ParameterDefinition pd)
-    => pd.HasCustomAttributes && pd.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System", "ParamArrayAttribute"));
+  public static bool IsParamArray(this ParameterDefinition pd) => pd.HasAttribute("System", "ParamArrayAttribute");
 
   // FIXME: Can the remove method differ? Does it matter?
   public static bool IsPublicApi(this EventDefinition ed) => ed.AddMethod.IsPublicApi();
@@ -313,20 +318,16 @@ internal static class CecilUtils {
     => td.IsPublic || td.IsNestedPublic || td.IsNestedFamily || td.IsNestedFamilyOrAssembly;
 
   public static bool IsReadOnly(this ICustomAttributeProvider? provider)
-    => provider is not null && provider.HasCustomAttributes &&
-       provider.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "IsReadOnlyAttribute"));
+    => provider.HasAttribute("System.Runtime.CompilerServices", "IsReadOnlyAttribute");
 
   public static bool IsRequired(this IMemberDefinition? md)
-    => md is not null && md.HasCustomAttributes &&
-       md.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "RequiredMemberAttribute"));
+    => md.HasAttribute("System.Runtime.CompilerServices", "RequiredMemberAttribute");
 
   public static bool IsScopedRef(this ParameterDefinition? pd)
-    => pd is not null && pd.HasCustomAttributes &&
-       pd.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "ScopedRefAttribute"));
+    => pd.HasAttribute("System.Runtime.CompilerServices", "ScopedRefAttribute");
 
   public static bool IsUnmanaged(this GenericParameter? gp)
-    => gp is not null && gp.HasCustomAttributes &&
-       gp.CustomAttributes.Any(ca => ca.AttributeType.IsNamed("System.Runtime.CompilerServices", "IsUnmanagedAttribute"));
+    => gp.HasAttribute("System.Runtime.CompilerServices", "IsUnmanagedAttribute");
 
   public static bool IsVoid(this TypeReference tr) => tr == tr.Module.TypeSystem.Void;
 

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -30,10 +30,10 @@ internal static class CecilUtils {
   extension(EventDefinition ed) {
 
     // FIXME: Can the remove method differ? Does it matter?
-    public bool IsInternalApi() => ed.AddMethod.IsInternalApi();
+    public bool IsInternalApi => ed.AddMethod.IsInternalApi;
 
     // FIXME: Can the remove method differ? Does it matter?
-    public bool IsPublicApi() => ed.AddMethod.IsPublicApi();
+    public bool IsPublicApi => ed.AddMethod.IsPublicApi;
 
   }
 
@@ -88,15 +88,15 @@ internal static class CecilUtils {
       return false;
     }
 
-    public bool IsInternalApi() => fd.IsAssembly || fd.IsFamilyAndAssembly;
+    public bool IsInternalApi => fd.IsAssembly || fd.IsFamilyAndAssembly;
 
-    public bool IsPublicApi() => fd.IsPublic || fd.IsFamily || fd.IsFamilyOrAssembly;
+    public bool IsPublicApi => fd.IsPublic || fd.IsFamily || fd.IsFamilyOrAssembly;
 
   }
 
   extension(GenericParameter? gp) {
 
-    public bool IsUnmanaged() => gp.HasAttribute("System.Runtime.CompilerServices", "IsUnmanagedAttribute");
+    public bool IsUnmanaged => gp.HasAttribute("System.Runtime.CompilerServices", "IsUnmanagedAttribute");
 
   }
 
@@ -105,8 +105,7 @@ internal static class CecilUtils {
     public Nullability? GetNullability(MethodDefinition? context, int idx = 0)
       => cap?.GetNullability(idx) ?? context.GetNullabilityContext();
 
-    public Nullability? GetNullability(MethodDefinition? methodContext,
-                                       TypeDefinition? typeContext, int idx = 0)
+    public Nullability? GetNullability(MethodDefinition? methodContext, TypeDefinition? typeContext, int idx = 0)
       => cap?.GetNullability(idx) ?? methodContext.GetNullabilityContext() ?? typeContext.GetNullabilityContext();
 
     public Nullability? GetNullability(TypeDefinition? context, int idx = 0)
@@ -211,7 +210,7 @@ internal static class CecilUtils {
       return false;
     }
 
-    public bool IsMarkedAsExtension() => cap.HasAttribute("System.Runtime.CompilerServices", "ExtensionAttribute");
+    public bool IsMarkedAsExtension => cap.HasAttribute("System.Runtime.CompilerServices", "ExtensionAttribute");
 
     public bool IsNativeInteger(int idx) {
       if (cap is not null && cap.HasCustomAttributes) {
@@ -237,13 +236,13 @@ internal static class CecilUtils {
       return false;
     }
 
-    public bool IsReadOnly() => cap.HasAttribute("System.Runtime.CompilerServices", "IsReadOnlyAttribute");
+    public bool IsReadOnly => cap.HasAttribute("System.Runtime.CompilerServices", "IsReadOnlyAttribute");
 
   }
 
   extension(IMemberDefinition? md) {
 
-    public bool IsRequired() => md.HasAttribute("System.Runtime.CompilerServices", "RequiredMemberAttribute");
+    public bool IsRequired => md.HasAttribute("System.Runtime.CompilerServices", "RequiredMemberAttribute");
 
   }
 
@@ -261,26 +260,21 @@ internal static class CecilUtils {
       return null;
     }
 
-    public bool HasCovariantReturn() => md.HasAttribute("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute");
+    public bool HasCovariantReturn => md.HasAttribute("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute");
 
-    public MethodDefinition? IfPublicApi() {
-      if (md is null) {
-        return null;
-      }
-      return md.IsPublicApi() ? md : null;
-    }
+    public MethodDefinition? IfPublicApi() => md.IsPublicApi ? md : null;
 
-    public bool IsInternalApi() => md is not null && (md.IsAssembly || md.IsFamilyAndAssembly);
+    public bool IsInternalApi => md is not null && (md.IsAssembly || md.IsFamilyAndAssembly);
 
-    public bool IsPublicApi() => md is not null && (md.IsPublic || md.IsFamily || md.IsFamilyOrAssembly);
+    public bool IsPublicApi => md is not null && (md.IsPublic || md.IsFamily || md.IsFamilyOrAssembly);
 
   }
 
   extension(ParameterDefinition? pd) {
 
-    public bool IsParamArray() => pd.HasAttribute("System", "ParamArrayAttribute");
+    public bool IsParamArray => pd.HasAttribute("System", "ParamArrayAttribute");
 
-    public bool IsScopedRef() => pd.HasAttribute("System.Runtime.CompilerServices", "ScopedRefAttribute");
+    public bool IsScopedRef => pd.HasAttribute("System.Runtime.CompilerServices", "ScopedRefAttribute");
 
   }
 
@@ -298,11 +292,9 @@ internal static class CecilUtils {
       return null;
     }
 
-    public bool IsByRefLike()
-      => td.HasAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute");
+    public bool IsByRefLike => td.HasAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute");
 
-    private bool IsCompilerGenerated()
-      => td is not null && td.HasAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
+    private bool IsCompilerGenerated => td.HasAttribute("System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
 
     public bool IsDelegate([NotNullWhen(true)] out MethodDefinition? invoke) {
       invoke = null;
@@ -333,19 +325,22 @@ internal static class CecilUtils {
       return invoke is not null;
     }
 
-    public bool IsExtensionBlock()
-      => td is not null && (td.IsSpecialName && td.IsMarkedAsExtension() && td.Name.StartsWith("<G>"));
+    public bool IsExtensionBlock => td is { IsSpecialName: true, IsMarkedAsExtension: true } && td.Name.StartsWith("<G>");
 
-    public bool IsInternalApi() => td is not null && (td.IsNestedAssembly || td.IsNestedFamilyAndAssembly || td.IsNotPublic);
+    public bool IsInternalApi => td is not null && (td.IsNestedAssembly || td.IsNestedFamilyAndAssembly || td.IsNotPublic);
 
-    public bool IsPublicApi()
+    public bool IsPublicApi
       => td is not null && (td.IsPublic || td.IsNestedPublic || td.IsNestedFamily || td.IsNestedFamilyOrAssembly);
 
   }
 
   extension(TypeReference tr) {
 
-    public bool IsCompilerGenerated() => tr.Resolve().IsCompilerGenerated();
+    public bool IsCompilerGenerated {
+      get {
+        return tr.Resolve().IsCompilerGenerated;
+      }
+    }
 
     public bool IsCoreLibraryType() => tr.Scope == tr.Module.TypeSystem.CoreLibrary;
 
@@ -363,7 +358,7 @@ internal static class CecilUtils {
 
     public bool IsNamed(string? ns, string name) => tr.Namespace == ns && tr.Name == name;
 
-    public bool IsVoid() => tr == tr.Module.TypeSystem.Void;
+    public bool IsVoid => tr == tr.Module.TypeSystem.Void;
 
     public string NonGenericName() {
       var name = tr.Name;

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -729,7 +729,7 @@ public abstract partial class CodeFormatter {
       if (!this.ShouldInclude(type)) {
         continue;
       }
-      if (type.IsExtensionBlock()) {
+      if (type.IsExtensionBlock) {
         continue;
       }
       if (nestedTypes.TryGetValue(type.Name, out var previousType)) {
@@ -839,14 +839,14 @@ public abstract partial class CodeFormatter {
     return this._attributesToExclude.All(pattern => !name.Matches(pattern));
   }
 
-  private bool ShouldInclude(EventDefinition ed) => ed.IsPublicApi() || (this.IncludeInternals && ed.IsInternalApi());
+  private bool ShouldInclude(EventDefinition ed) => ed.IsPublicApi || (this.IncludeInternals && ed.IsInternalApi);
 
-  private bool ShouldInclude(FieldDefinition fd) => fd.IsPublicApi() || (this.IncludeInternals && fd.IsInternalApi());
+  private bool ShouldInclude(FieldDefinition fd) => fd.IsPublicApi || (this.IncludeInternals && fd.IsInternalApi);
 
   private bool ShouldInclude(MethodDefinition? md)
-    => md is not null && (md.IsPublicApi() || (this.IncludeInternals && md.IsInternalApi()));
+    => md is not null && (md.IsPublicApi || (this.IncludeInternals && md.IsInternalApi));
 
-  private bool ShouldInclude(TypeDefinition td) => td.IsPublicApi() || (this.IncludeInternals && td.IsInternalApi());
+  private bool ShouldInclude(TypeDefinition td) => td.IsPublicApi || (this.IncludeInternals && td.IsInternalApi);
 
   private IEnumerable<string?> TopLevelAttributes(AssemblyDefinition ad) {
     foreach (var line in this.CustomAttributes(ad)) {

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -281,7 +281,7 @@ public abstract partial class CodeFormatter {
   /// <param name="indent">The number of spaces of indentation to use.</param>
   /// <returns>The formatted blocks.</returns>
   protected IEnumerable<string?> ExtensionBlocks(TypeDefinition td, int indent) {
-    if (!td.HasNestedTypes) {
+    if (!this.IncludeExtensionBlocks || !td.HasNestedTypes) {
       yield break;
     }
     var blocks = new List<TypeDefinition>();
@@ -555,7 +555,14 @@ public abstract partial class CodeFormatter {
   }
 
   /// <summary>
-  /// Indicates whether the public API should be considered to include <code>internal</code> and <code>private protected</code>
+  /// Determines whether extension blocks (as introduced by C# 14) will also be present in the produced API reference.<br/>
+  /// By default, they are not, because the implementing methods are always included (they are not marked so cannot be easily
+  /// identified for omission). As such, the extension blocks only duplicate information.
+  /// </summary>
+  public bool IncludeExtensionBlocks { get; set; }
+
+  /// <summary>
+  /// Determines whether the public API should be considered to include <code>internal</code> and <code>private protected</code>
   /// items instead of only <code>public</code> and <code>protected</code> ones.
   /// </summary>
   public bool IncludeInternals { get; set; }

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -729,6 +729,9 @@ public abstract partial class CodeFormatter {
       if (!this.ShouldInclude(type)) {
         continue;
       }
+      if (type.IsExtensionBlock()) {
+        continue;
+      }
       if (nestedTypes.TryGetValue(type.Name, out var previousType)) {
         Trace.Fail(type.ToString(), $"Multiply defined nested type in {td}; previous was {previousType}.");
       }

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -12,15 +12,6 @@ namespace Zastai.Build.ApiReference;
 /// <summary>A class that will extract and format the public API for an assembly.</summary>
 public abstract partial class CodeFormatter {
 
-  /// <summary>The name of the namespace currently being processed.</summary>
-  protected string? CurrentNamespace { get; private set; }
-
-  /// <summary>The type definition currently being processed.</summary>
-  protected TypeDefinition? CurrentType { get; private set; }
-
-  /// <summary>The number of spaces to be used to indent a top-level type.</summary>
-  protected virtual int TopLevelTypeIndent => 0;
-
   private readonly HashSet<string> _attributesToExclude = [];
 
   private readonly HashSet<string> _attributesToInclude = [];
@@ -66,6 +57,12 @@ public abstract partial class CodeFormatter {
     this._attributesToInclude.Clear();
     this._attributesToExclude.Clear();
   }
+
+  /// <summary>The name of the namespace currently being processed.</summary>
+  protected string? CurrentNamespace { get; private set; }
+
+  /// <summary>The type definition currently being processed.</summary>
+  protected TypeDefinition? CurrentType { get; private set; }
 
   /// <summary>Formats a custom attribute.</summary>
   /// <param name="ca">The custom attribute to format.</param>
@@ -231,6 +228,20 @@ public abstract partial class CodeFormatter {
     }
   }
 
+  /// <summary>Adds patterns indicating attributes that should be excluded from the output.</summary>
+  /// <param name="patterns">
+  /// The patterns to exclude (using simple shell wildcards: <c>*</c> or <c>?</c>). Note that matches are against the internal name
+  /// of the attribute, so <c>Foo/BarAttribute`1</c> for a <c>BarAttribute&lt;T&gt;</c> attribute type nested in a <c>Foo</c> class.
+  /// </param>
+  public void ExcludeCustomAttributes(IEnumerable<string> patterns) {
+    foreach (var pattern in patterns) {
+      if (string.IsNullOrWhiteSpace(pattern)) {
+        continue;
+      }
+      this._attributesToExclude.Add(pattern.Trim());
+    }
+  }
+
   private IEnumerable<string?> ExportedTypes(AssemblyDefinition ad) {
     var exportedTypes = new SortedDictionary<string, IDictionary<string, ExportedType>>();
     foreach (var md in ad.Modules) {
@@ -254,24 +265,41 @@ public abstract partial class CodeFormatter {
     return exportedTypes.Count == 0 ? [] : this.ExportedTypes(exportedTypes);
   }
 
-  /// <summary>Adds patterns indicating attributes that should be excluded from the output.</summary>
-  /// <param name="patterns">
-  /// The patterns to exclude (using simple shell wildcards: <c>*</c> or <c>?</c>). Note that matches are against the internal name
-  /// of the attribute, so <c>Foo/BarAttribute`1</c> for a <c>BarAttribute&lt;T&gt;</c> attribute type nested in a <c>Foo</c> class.
-  /// </param>
-  public void ExcludeCustomAttributes(IEnumerable<string> patterns) {
-    foreach (var pattern in patterns) {
-      if (string.IsNullOrWhiteSpace(pattern)) {
-        continue;
-      }
-      this._attributesToExclude.Add(pattern.Trim());
-    }
-  }
-
   /// <summary>Formats the types exported by an assembly.</summary>
   /// <param name="exportedTypes">The exported types (grouped by their scope).</param>
   /// <returns>The formatted exported types.</returns>
   protected abstract IEnumerable<string?> ExportedTypes(SortedDictionary<string, IDictionary<string, ExportedType>> exportedTypes);
+
+  /// <summary>Formats an extension block.</summary>
+  /// <param name="td">The type representing the extension block.</param>
+  /// <param name="indent">The number of spaces of indentation to use.</param>
+  /// <returns>The formatted field (one line).</returns>
+  protected abstract IEnumerable<string?> ExtensionBlock(TypeDefinition td, int indent);
+
+  /// <summary>Formats the extension blocks declared by a type.</summary>
+  /// <param name="td">The type to process.</param>
+  /// <param name="indent">The number of spaces of indentation to use.</param>
+  /// <returns>The formatted blocks.</returns>
+  protected IEnumerable<string?> ExtensionBlocks(TypeDefinition td, int indent) {
+    if (!td.HasNestedTypes) {
+      yield break;
+    }
+    var blocks = new List<TypeDefinition>();
+    foreach (var type in td.NestedTypes) {
+      if (!this.ShouldInclude(type) || !type.IsExtensionBlock || type is { HasMethods: false, HasProperties: false }) {
+        continue;
+      }
+      blocks.Add(type);
+    }
+    if (blocks.Count == 0) {
+      yield break;
+    }
+    foreach (var block in blocks) {
+      foreach (var line in this.ExtensionBlock(block, indent)) {
+        yield return line;
+      }
+    }
+  }
 
   /// <summary>Formats a field.</summary>
   /// <param name="fd">The field to format.</param>
@@ -858,6 +886,9 @@ public abstract partial class CodeFormatter {
       }
     }
   }
+
+  /// <summary>The number of spaces to be used to indent a top-level type.</summary>
+  protected virtual int TopLevelTypeIndent => 0;
 
   private IEnumerable<string?> TopLevelTypes(AssemblyDefinition ad) {
     // Gather all types, grouping them by namespace.

--- a/Zastai.Build.ApiReference.Tool/Program.cs
+++ b/Zastai.Build.ApiReference.Tool/Program.cs
@@ -57,6 +57,7 @@ public static class Program {
     var handleBinaryEnums = false;
     var handleCharEnums = false;
     var handleHexEnums = false;
+    var includeExtensionBlocks = false;
     var includeInternals = false;
     var dependencyPath = new List<string>();
     var includedAttributes = new List<string>();
@@ -66,6 +67,21 @@ public static class Program {
         case "-ea":
           excludedAttributes.Add(args[i + 1]);
           break;
+        case "-eb":{
+          var value = args[i + 1];
+          switch (value.Trim().ToLowerInvariant()) {
+            case "include":
+              includeExtensionBlocks = true;
+              break;
+            case "omit":
+              includeExtensionBlocks = false;
+              break;
+            default:
+              Console.Error.WriteLine($"Unsupported extension block setting: '{value}'; should be either 'include' or 'omit'.");
+              return 4;
+          }
+          break;
+        }
         case "-eh":
           foreach (var handling in args[i + 1].Split(',', ';')) {
             switch (handling.Trim().ToLowerInvariant()) {
@@ -120,7 +136,7 @@ public static class Program {
               includeInternals = false;
               break;
             default:
-              Console.Error.WriteLine($"Unsupported visibility ({visibility}) specified; should be either 'public' or 'internal'.");
+              Console.Error.WriteLine($"Unsupported visibility: '{visibility}'; should be either 'public' or 'internal'.");
               return 4;
           }
           break;
@@ -136,6 +152,7 @@ public static class Program {
     formatter.EnableHexEnums(handleHexEnums);
     formatter.ExcludeCustomAttributes(excludedAttributes);
     formatter.IncludeCustomAttributes(includedAttributes);
+    formatter.IncludeExtensionBlocks = includeExtensionBlocks;
     formatter.IncludeInternals = includeInternals;
     try {
       using var reference = referenceSource == "-" ? Console.Out : new StreamWriter(File.Create(referenceSource), Encoding.UTF8);

--- a/Zastai.Build.ApiReference.Tool/README.md
+++ b/Zastai.Build.ApiReference.Tool/README.md
@@ -52,6 +52,15 @@ Attributes handled as part of syntax generation (like
 `System.Runtime.CompilerServices.ExtensionAttribute`) are never
 included.
 
+#### `-eb true/false`
+
+If this is specified as `true`, then extension blocks (as introduced by
+C# 14) will also be present in the produced API reference.
+
+By default, they are not, because the implementing methods are always
+included (they are not marked so cannot be easily identified for
+omission). As such, the extension blocks only duplicate information.
+
 #### `-eh ENUM-HANDLING`
 
 Activate specific enum handling (one or more flags, comma-separated).

--- a/Zastai.Build.ApiReference/GenerateApiReference.cs
+++ b/Zastai.Build.ApiReference/GenerateApiReference.cs
@@ -34,6 +34,8 @@ public sealed class GenerateApiReference : ITask {
 
   public ITaskItem[] IncludeAttributes { get; set; } = [];
 
+  public bool IncludeExtensionBlocks { get; set; }
+
   public ITaskItem[] LibraryPath { get; set; } = [];
 
   [Required]
@@ -148,6 +150,7 @@ public sealed class GenerateApiReference : ITask {
     formatter.EnableHexEnums(handleHexEnums);
     formatter.ExcludeCustomAttributes(excludedAttributes);
     formatter.IncludeCustomAttributes(includedAttributes);
+    formatter.IncludeExtensionBlocks = this.IncludeExtensionBlocks;
     formatter.IncludeInternals = includeInternals;
     try {
       using var reference = new StreamWriter(File.Create(referenceSource), Encoding.UTF8);

--- a/Zastai.Build.ApiReference/README.md
+++ b/Zastai.Build.ApiReference/README.md
@@ -92,6 +92,15 @@ assembly.
 
 Defaults to `true`.
 
+### IncludeExtensionBlocksInApiReference
+
+If this is set to `true`, then extension blocks (as introduced by C# 14)
+will also be present in the produced API reference.
+
+By default, they are not, because the implementing methods are always
+included (they are not marked so cannot be easily identified for
+omission). As such, the extension blocks only duplicate information.
+
 ### SkipApiReferenceOutputPathFileWrite
 
 Determines whether the output files are registered in `@(FileWrites)`.

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.props
@@ -5,17 +5,14 @@
   <!-- Attributes to include in the API reference.
      - If this item group is empty, all attributes are included unless further excluded via @(ApiReferenceExcludeAttribute). -->
   <ItemGroup>
-    <!-- <ApiReferenceIncludeAttribute Include="..." /> -->
-
     <!-- Empty by default (i.e. all attributes are included). -->
-
+    <!-- <ApiReferenceIncludeAttribute Include="..." /> -->
   </ItemGroup>
 
   <!-- Attributes to exclude from the API reference; applied to attributes included via @(ApiReferenceIncludeAttribute).
      - If this item group is empty, all attributes are included. -->
   <ItemGroup>
     <!-- <ApiReferenceExcludeAttribute Include="..." /> -->
-
     <ApiReferenceExcludeAttribute Include="__DynamicallyInvokableAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Diagnostics.CodeAnalysis.SuppressMessageAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Diagnostics.DebuggableAttribute" />
@@ -44,7 +41,6 @@
     <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.RefSafetyRulesAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Runtime.CompilerServices.RuntimeCompatibilityAttribute" />
     <ApiReferenceExcludeAttribute Include="System.Runtime.Versioning.RequiresPreviewFeaturesAttribute" />
-
   </ItemGroup>
 
 </Project>

--- a/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
+++ b/Zastai.Build.ApiReference/build/Zastai.Build.ApiReference.targets
@@ -66,7 +66,7 @@
 
     <!-- Create the output directory (if requested to do so). -->
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetFullPath('$(ApiReferenceOutputPath)'))))"
-             Condition=" '$(CreateApiReferenceOutputDir)' == 'true' "/>
+             Condition=" '$(CreateApiReferenceOutputDir)' == 'true' " />
 
     <!-- Enum Handling -->
     <ItemGroup>
@@ -96,12 +96,13 @@
                           ExcludeAttributes="@(APIReferenceExcludeAttribute)"
                           Format="$(_ApiReferenceFormat)"
                           IncludeAttributes="@(APIReferenceIncludeAttribute)"
+                          IncludeExtensionBlocks="$(IncludeExtensionBlocksInApiReference)"
                           LibraryPath="@(_DirectoriesContainingReferencedAssemblies)"
                           OutputPath="$(ApiReferenceOutputPath)"
                           Visibility="$(VisibilityForApiReference)" />
 
     <ItemGroup>
-      <FileWrites Condition=" '$(SkipApiReferenceOutputPathFileWrite)' != 'true' " Include="$(ApiReferenceOutputPath) "/>
+      <FileWrites Condition=" '$(SkipApiReferenceOutputPathFileWrite)' != 'true' " Include="$(ApiReferenceOutputPath) " />
     </ItemGroup>
 
     <Message Text="Generated API Reference: $(ApiReferenceOutputPath)" Importance="high" />


### PR DESCRIPTION
This ensures the special nested types are not included in the API reference.

Optionally, their syntax form can be included in the API reference; but because currently the underlying implementation methods cannot easily be omitted, this essentially duplicates information, so this is not enabled by default.

Fixes #89.