### PR TITLE
Add proper support for `record` and `union`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      dotnet-version: 10.0.x
+      dotnet-version: 11.0.x
+      dotnet-quality: preview
     permissions:
       attestations: write
       id-token: write
@@ -31,7 +32,7 @@ jobs:
       id: setup
       with:
         dotnet-version: ${{env.dotnet-version}}
-        dotnet-quality: ga
+        dotnet-quality: ${{env.dotnet-quality}}
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net11.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -652,6 +652,22 @@ public class CSharpFormatter : CodeFormatter {
     return false;
   }
 
+  /// <summary>Determines whether a given type definition is for a C# record type.</summary>
+  /// <param name="td">The type definition to check.</param>
+  /// <returns><see langword="true"/> if it's a record type; <see langword="false"/> otherwise.</returns>
+  protected bool IsRecordType(TypeDefinition td) {
+    // TODO
+    return false;
+  }
+
+  /// <summary>Determines whether a given type definition is for a C# union type.</summary>
+  /// <param name="td">The type definition to check.</param>
+  /// <returns><see langword="true"/> if it's a union type; <see langword="false"/> otherwise.</returns>
+  protected bool IsUnionType(TypeDefinition td) {
+    // TODO
+    return false;
+  }
+
   /// <inheritdoc />
   protected override string LineComment(string comment) => $"// {comment}".TrimEnd();
 
@@ -1228,139 +1244,11 @@ public class CSharpFormatter : CodeFormatter {
     yield return $"namespace {this.CurrentNamespace};";
   }
 
-  /// <inheritdoc />
-  protected override string Null() => "null";
-
-  /// <inheritdoc />
-  protected override string Or() => "|";
-
-  private string Parameter(ParameterDefinition pd) {
-    var sb = new StringBuilder();
-    sb.Append(this.CustomAttributesInline(pd));
-    if (pd.IsScopedRef) {
-      sb.Append("scoped ");
-    }
-    if (pd.IsIn) {
-      sb.Append("in ");
-    }
-    if (pd.IsOut) {
-      sb.Append("out ");
-    }
-    if (pd.IsParamArray) {
-      sb.Append("params ");
-    }
-    sb.Append(this.TypeName(pd.ParameterType, pd)).Append(' ').Append(pd.Name);
-    if (pd.HasDefault) {
-      sb.Append(" = ");
-      // FIXME: How to tell the difference between `default` and `new()`?
-      if (!pd.HasConstant) {
-        sb.Append("/* constant value missing */");
-      }
-      else if (pd.Constant is null && pd.ParameterType.IsValueType) {
-        sb.Append("default");
-      }
-      else {
-        sb.Append(this.Value(pd.ParameterType, pd.Constant));
-      }
-    }
-    return sb.ToString();
-  }
-
-  private string Parameters(MethodDefinition md) {
-    var sb = new StringBuilder();
-    sb.Append('(');
-    if (md.HasParameters) {
-      // Detect extension methods
-      if (md.IsMarkedAsExtension) {
-        sb.Append("this ");
-      }
-      sb.AppendJoin(", ", md.Parameters.Select(this.Parameter));
-    }
-    sb.Append(')');
-    return sb.ToString();
-  }
-
-  private string Parameters(PropertyDefinition pd) {
-    if (!pd.HasParameters) {
-      return "";
-    }
-    var sb = new StringBuilder();
-    // Assumption: only indexers have parameters, and they use []
-    sb.Append('[').AppendJoin(", ", pd.Parameters.Select(this.Parameter)).Append(']');
-    return sb.ToString();
-  }
-
-  /// <inheritdoc />
-  protected override IEnumerable<string?> Property(PropertyDefinition pd, int indent) {
-    foreach (var line in this.CustomAttributes(pd, indent)) {
-      yield return line;
-    }
-    {
-      var sb = new StringBuilder();
-      sb.Append(' ', indent);
-      if (pd.IsRequired) {
-        sb.Append("required ");
-      }
-      sb.Append(this.TypeName(pd.PropertyType, pd)).Append(' ');
-      sb.Append(this.PropertyName(pd));
-      sb.Append(this.Parameters(pd)).Append(" {");
-      yield return sb.ToString();
-    }
-    foreach (var line in this.PropertyAccessor(pd.GetMethod.IfPublicApi(), indent + 2)) {
-      yield return line;
-    }
-    foreach (var line in this.PropertyAccessor(pd.SetMethod.IfPublicApi(), indent + 2)) {
-      yield return line;
-    }
-    if (pd.HasOtherMethods) {
-      var sb = new StringBuilder();
-      sb.Append(' ', indent + 2).Append("// unsupported: \"other methods\"");
-      yield return sb.ToString();
-    }
-    {
-      var sb = new StringBuilder();
-      sb.Append(' ', indent).Append('}');
-      yield return sb.ToString();
-    }
-  }
-
-  private IEnumerable<string?> PropertyAccessor(MethodDefinition? method, int indent) {
-    if (method is null) {
-      yield break;
-    }
-    foreach (var line in this.CustomAttributes(method, indent)) {
-      yield return line;
-    }
-    var sb = new StringBuilder();
-    sb.Append(' ', indent).Append(this.Attributes(method));
-    if (method.IsReadOnly) {
-      sb.Append("readonly ");
-    }
-    if (method.IsGetter) {
-      sb.Append("get");
-    }
-    else if (method.IsSetter) {
-      // For `init`, it's not an attribute on the setter method, but rather a "required modifier" on its return type (void).
-      // A bit weird, but whatever.
-      if (method.ReturnType.IsModifiedType(method.Module.TypeSystem.Void, "System.Runtime.CompilerServices", "IsExternalInit")) {
-        sb.Append("init");
-      }
-      else {
-        sb.Append("set");
-      }
-    }
-    sb.Append(';');
-    yield return sb.ToString();
-  }
-
-  /// <inheritdoc />
-  protected override string PropertyName(PropertyDefinition pd) {
-    // FIXME: Or should this only be done when the type has [System.Reflection.DefaultMemberAttribute("Item")]?
-    return pd is { HasParameters: true, Name: "Item" } ? "this" : pd.Name;
-  }
-
-  /// <inheritdoc />
-  protected override IEnumerable<string?> Type(TypeDefinition td, int indent) {
+  /// <summary>Formats a "normal" C# type (i.e. not a record or union type).</summary>
+  /// <param name="td">The type definition.</param>
+  /// <param name="indent">The number of spaces of indentation to use.</param>
+  /// <returns>The formatted type.</returns>
+  protected IEnumerable<string?> NormalType(TypeDefinition td, int indent) {
     foreach (var line in this.CustomAttributes(td, indent)) {
       yield return line;
     }
@@ -1527,6 +1415,157 @@ public class CSharpFormatter : CodeFormatter {
     yield return null;
     sb.Append(' ', indent).Append('}');
     yield return sb.ToString();
+  }
+
+  /// <inheritdoc />
+  protected override string Null() => "null";
+
+  /// <inheritdoc />
+  protected override string Or() => "|";
+
+  private string Parameter(ParameterDefinition pd) {
+    var sb = new StringBuilder();
+    sb.Append(this.CustomAttributesInline(pd));
+    if (pd.IsScopedRef) {
+      sb.Append("scoped ");
+    }
+    if (pd.IsIn) {
+      sb.Append("in ");
+    }
+    if (pd.IsOut) {
+      sb.Append("out ");
+    }
+    if (pd.IsParamArray) {
+      sb.Append("params ");
+    }
+    sb.Append(this.TypeName(pd.ParameterType, pd)).Append(' ').Append(pd.Name);
+    if (pd.HasDefault) {
+      sb.Append(" = ");
+      // FIXME: How to tell the difference between `default` and `new()`?
+      if (!pd.HasConstant) {
+        sb.Append("/* constant value missing */");
+      }
+      else if (pd.Constant is null && pd.ParameterType.IsValueType) {
+        sb.Append("default");
+      }
+      else {
+        sb.Append(this.Value(pd.ParameterType, pd.Constant));
+      }
+    }
+    return sb.ToString();
+  }
+
+  private string Parameters(MethodDefinition md) {
+    var sb = new StringBuilder();
+    sb.Append('(');
+    if (md.HasParameters) {
+      // Detect extension methods
+      if (md.IsMarkedAsExtension) {
+        sb.Append("this ");
+      }
+      sb.AppendJoin(", ", md.Parameters.Select(this.Parameter));
+    }
+    sb.Append(')');
+    return sb.ToString();
+  }
+
+  private string Parameters(PropertyDefinition pd) {
+    if (!pd.HasParameters) {
+      return "";
+    }
+    var sb = new StringBuilder();
+    // Assumption: only indexers have parameters, and they use []
+    sb.Append('[').AppendJoin(", ", pd.Parameters.Select(this.Parameter)).Append(']');
+    return sb.ToString();
+  }
+
+  /// <inheritdoc />
+  protected override IEnumerable<string?> Property(PropertyDefinition pd, int indent) {
+    foreach (var line in this.CustomAttributes(pd, indent)) {
+      yield return line;
+    }
+    {
+      var sb = new StringBuilder();
+      sb.Append(' ', indent);
+      if (pd.IsRequired) {
+        sb.Append("required ");
+      }
+      sb.Append(this.TypeName(pd.PropertyType, pd)).Append(' ');
+      sb.Append(this.PropertyName(pd));
+      sb.Append(this.Parameters(pd)).Append(" {");
+      yield return sb.ToString();
+    }
+    foreach (var line in this.PropertyAccessor(pd.GetMethod.IfPublicApi(), indent + 2)) {
+      yield return line;
+    }
+    foreach (var line in this.PropertyAccessor(pd.SetMethod.IfPublicApi(), indent + 2)) {
+      yield return line;
+    }
+    if (pd.HasOtherMethods) {
+      var sb = new StringBuilder();
+      sb.Append(' ', indent + 2).Append("// unsupported: \"other methods\"");
+      yield return sb.ToString();
+    }
+    {
+      var sb = new StringBuilder();
+      sb.Append(' ', indent).Append('}');
+      yield return sb.ToString();
+    }
+  }
+
+  private IEnumerable<string?> PropertyAccessor(MethodDefinition? method, int indent) {
+    if (method is null) {
+      yield break;
+    }
+    foreach (var line in this.CustomAttributes(method, indent)) {
+      yield return line;
+    }
+    var sb = new StringBuilder();
+    sb.Append(' ', indent).Append(this.Attributes(method));
+    if (method.IsReadOnly) {
+      sb.Append("readonly ");
+    }
+    if (method.IsGetter) {
+      sb.Append("get");
+    }
+    else if (method.IsSetter) {
+      // For `init`, it's not an attribute on the setter method, but rather a "required modifier" on its return type (void).
+      // A bit weird, but whatever.
+      if (method.ReturnType.IsModifiedType(method.Module.TypeSystem.Void, "System.Runtime.CompilerServices", "IsExternalInit")) {
+        sb.Append("init");
+      }
+      else {
+        sb.Append("set");
+      }
+    }
+    sb.Append(';');
+    yield return sb.ToString();
+  }
+
+  /// <inheritdoc />
+  protected override string PropertyName(PropertyDefinition pd) {
+    // FIXME: Or should this only be done when the type has [System.Reflection.DefaultMemberAttribute("Item")]?
+    return pd is { HasParameters: true, Name: "Item" } ? "this" : pd.Name;
+  }
+
+  /// <summary>Formats a C# record type.</summary>
+  /// <param name="td">The record type definition.</param>
+  /// <param name="indent">The number of spaces of indentation to use.</param>
+  /// <returns>The formatted record type.</returns>
+  protected IEnumerable<string?> RecordType(TypeDefinition td, int indent) {
+    // TODO
+    yield break;
+  }
+
+  /// <inheritdoc />
+  protected override IEnumerable<string?> Type(TypeDefinition td, int indent) {
+    if (this.IsRecordType(td)) {
+      return this.RecordType(td, indent);
+    }
+    if (this.IsUnionType(td)) {
+      return this.UnionType(td, indent);
+    }
+    return this.NormalType(td, indent);
   }
 
   /// <summary>Formats the type name for an exported type.</summary>
@@ -1872,6 +1911,15 @@ public class CSharpFormatter : CodeFormatter {
   protected override string TypeOf(TypeReference tr) {
     // FIXME: Does this need a context?
     return $"typeof({this.TypeName(tr)})";
+  }
+
+  /// <summary>Formats a C# union type.</summary>
+  /// <param name="td">The union type definition.</param>
+  /// <param name="indent">The number of spaces of indentation to use.</param>
+  /// <returns>The formatted union type.</returns>
+  protected IEnumerable<string?> UnionType(TypeDefinition td, int indent) {
+    // TODO
+    yield break;
   }
 
 }

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -114,7 +114,7 @@ public class CSharpFormatter : CodeFormatter {
     else if (md.IsVirtual) {
       // For some reason, static virtual methods in interfaces have IsReuseSlot set; that's currently the only situation where
       // static+virtual is valid, so we can just look at IsStatic to ignore the IsReuseSlot.
-      var isOverride = md is { IsReuseSlot: true, IsStatic: false } || (md.IsNewSlot && md.HasCovariantReturn);
+      var isOverride = md is { IsReuseSlot: true, IsStatic: false } or { IsNewSlot: true, HasCovariantReturn: true };
       sb.Append(isOverride ? "override " : "virtual ");
     }
     return sb.ToString();

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -655,54 +655,41 @@ public class CSharpFormatter : CodeFormatter {
   /// <summary>Determines whether a given type definition is for a C# record type.</summary>
   /// <param name="td">The type definition to check.</param>
   /// <returns><see langword="true"/> if it's a record type; <see langword="false"/> otherwise.</returns>
-  protected bool IsRecordType(TypeDefinition td) {
+  protected static bool IsRecordType(TypeDefinition td) {
     // Can't be an interface or an enum; can't be a static class.
     if (td.IsInterface || td.IsEnum || td is { IsSealed: true, IsAbstract: true }) {
       return false;
     }
-    // Must have implemented interfaces and methods. Properties and fields are not technically required.
-    if (!td.HasInterfaces || !td.HasMethods) {
+    // Must implement IEquatable<itself>.
+    if (!td.Implements("System", "IEquatable`1", td)) {
       return false;
-    }
-    { // Must implement IEquatable<itself>.
-      var found = false;
-      foreach (var implemented in td.Interfaces.Select(ii => ii.InterfaceType).OfType<GenericInstanceType>()) {
-        if (!implemented.ElementType.IsCoreLibraryType("System", "IEquatable`1")) {
-          continue;
-        }
-        if (implemented.HasGenericArguments && implemented.GenericArguments.Count == 1 && implemented.GenericArguments[0] == td) {
-          found = true;
-          break;
-        }
-      }
-      if (!found) {
-        return false;
-      }
     }
     var ts = td.Module.TypeSystem;
     { // Check for compiler-generated == and != operators.
       var eq = false;
       var neq = false;
-      var ops = td.Methods.Where(md => md is {
-        IsCompilerGenerated: true,
-        IsSpecialName: true,
-        IsStatic: true,
-        Name: "op_Equality" or "op_Inequality",
-        HasParameters: true,
-        Parameters.Count: 2,
-      });
-      foreach (var op in ops) {
-        if (op.ReturnType != ts.Boolean) {
-          continue;
-        }
-        if (op.Parameters[0].ParameterType != td || op.Parameters[1].ParameterType != td) {
-          continue;
-        }
-        if (op.Name is "op_Equality") {
-          eq = true;
-        }
-        else {
-          neq = true;
+      if (td.HasMethods) {
+        var ops = td.Methods.Where(md => md is {
+          IsCompilerGenerated: true,
+          IsSpecialName: true,
+          IsStatic: true,
+          Name: "op_Equality" or "op_Inequality",
+          HasParameters: true,
+          Parameters.Count: 2,
+        });
+        foreach (var op in ops) {
+          if (op.ReturnType != ts.Boolean) {
+            continue;
+          }
+          if (op.Parameters[0].ParameterType != td || op.Parameters[1].ParameterType != td) {
+            continue;
+          }
+          if (op.Name is "op_Equality") {
+            eq = true;
+          }
+          else {
+            neq = true;
+          }
         }
       }
       if (!eq || !neq) {
@@ -791,9 +778,50 @@ public class CSharpFormatter : CodeFormatter {
   /// <summary>Determines whether a given type definition is for a C# union type.</summary>
   /// <param name="td">The type definition to check.</param>
   /// <returns><see langword="true"/> if it's a union type; <see langword="false"/> otherwise.</returns>
-  protected bool IsUnionType(TypeDefinition td) {
-    // TODO
-    return false;
+  protected static bool IsUnionType(TypeDefinition td) {
+    // Automatic unions seem to always be structs. [Union] is required.
+    if (!td.IsValueType || !td.BaseType.IsCoreLibraryType("System", "ValueType") || !td.IsMarkedAsUnion) {
+      return false;
+    }
+    // They must implement IUnion.
+    if (!td.HasInterfaces || !td.Implements("System.Runtime.CompilerServices", "IUnion")) {
+      return false;
+    }
+    { // They must have a public get-only Value property of type object.
+      var found = false;
+      if (td.HasProperties) {
+        var ts = td.Module.TypeSystem;
+        foreach (var prop in td.Properties) {
+          if (prop is not { Name: "Value", GetMethod: { IsPublic: true }, SetMethod: null, HasOtherMethods: false }) {
+            continue;
+          }
+          if (prop.PropertyType == ts.Object) {
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) {
+        return false;
+      }
+    }
+    // All single-argument constructors, of which there must be at least one, must be public and compiler-generated.
+    {
+      var validConstructors = 0;
+      if (td.HasMethods) {
+        foreach (var ctor in td.Methods.Where(md => md is { IsConstructor: true, Name: ".ctor", HasParameters: true })) {
+          if (ctor.Parameters.Count == 1) {
+            if (ctor is { IsPublic: true, IsCompilerGenerated: true }) {
+              ++validConstructors;
+            }
+            else {
+              return false;
+            }
+          }
+        }
+      }
+      return validConstructors > 0;
+    }
   }
 
   /// <inheritdoc />
@@ -1372,189 +1400,6 @@ public class CSharpFormatter : CodeFormatter {
     yield return $"namespace {this.CurrentNamespace};";
   }
 
-  /// <summary>Formats a "normal" C# type (i.e. not a record or union type).</summary>
-  /// <param name="td">The type definition.</param>
-  /// <param name="indent">The number of spaces of indentation to use.</param>
-  /// <returns>The formatted type.</returns>
-  protected IEnumerable<string?> NormalType(TypeDefinition td, int indent) {
-    foreach (var line in this.CustomAttributes(td, indent)) {
-      yield return line;
-    }
-    var sb = new StringBuilder();
-    // This IL flag is written as an attribute in C# code. Do the same.
-    if (td.IsSerializable) {
-      sb.Append(' ', indent).Append('[').Append(typeof(SerializableAttribute).FullName).Append(']');
-      yield return sb.ToString();
-      sb.Clear();
-    }
-    sb.Append(' ', indent);
-    if (td.IsPublic || td.IsNestedPublic) {
-      sb.Append("public ");
-    }
-    else if (td.IsNestedAssembly || td.IsNotPublic) {
-      sb.Append("internal ");
-    }
-    else if (td.IsNestedFamily) {
-      sb.Append("protected ");
-    }
-    else if (td.IsNestedFamilyAndAssembly) {
-      sb.Append("private protected ");
-    }
-    else if (td.IsNestedFamilyOrAssembly) {
-      sb.Append("protected ");
-      if (this.IncludeInternals) {
-        sb.Append("internal ");
-      }
-    }
-    else {
-      sb.Append("/* unexpected accessibility */ ");
-    }
-    if (td.IsDelegate(out var invoke)) {
-      sb.Append("delegate ");
-      this.MethodName(invoke, out var returnTypeName);
-      if (returnTypeName.Length > 0) {
-        sb.Append(returnTypeName).Append(' ');
-      }
-      sb.Append(this.TypeName(td)).Append(this.Parameters(invoke));
-      var constraints = this.GenericParameterConstraints(td, indent + 2).ToList();
-      if (constraints.Count == 0) {
-        sb.Append(';');
-      }
-      else {
-        constraints[constraints.Count - 1] += ';';
-      }
-      yield return sb.ToString();
-      sb.Clear();
-      foreach (var constraint in constraints) {
-        yield return constraint;
-      }
-      yield break;
-    }
-    if (td is { IsClass: true, IsAbstract: true, IsSealed: true }) {
-      sb.Append("static ");
-    }
-    else if (td is { IsAbstract: true, IsInterface: false }) {
-      sb.Append("abstract ");
-    }
-    else if (td is { IsSealed: true, IsValueType: false }) {
-      sb.Append("sealed ");
-    }
-    var recordType = this.IsRecordType(td);
-    if (recordType) {
-      sb.Append("record");
-      if (td.IsValueType) {
-        sb.Append(" struct");
-      }
-    }
-    else if (td.IsEnum) {
-      sb.Append("enum");
-    }
-    else if (td.IsInterface) {
-      sb.Append("interface");
-    }
-    else if (td.IsValueType) {
-      if (td.IsReadOnly) {
-        sb.Append("readonly ");
-      }
-      if (td.IsByRefLike) {
-        sb.Append("ref ");
-      }
-      sb.Append("struct");
-    }
-    else if (td.IsClass) {
-      // TODO: Maybe detect delegates; but then what of explicitly written classes deriving from MultiCastDelegate?
-      sb.Append("class");
-    }
-    else { // What else can it be?
-      sb.Append($"/* type with unsupported classification: {td.Attributes} */");
-    }
-    // Note: The definition is NOT passed as context here (otherwise [NullableContext(2)] causes "public class Foo?").
-    sb.Append(' ').Append(this.TypeName(td));
-    {
-      var baseType = td.BaseType;
-      if (baseType is not null) {
-        if (td.IsClass && baseType.IsCoreLibraryType("System", "Object")) {
-          baseType = null;
-        }
-        else if (td.IsEnum && baseType.IsCoreLibraryType("System", "Enum")) {
-          baseType = null;
-        }
-        else if (td.IsValueType && baseType.IsNamed("System", "ValueType")) {
-          baseType = null;
-        }
-      }
-      // For an enum, look for the special-named 'value__' field and use its type as the base type.
-      if (baseType is null && td is { IsEnum: true, HasFields: true }) {
-        foreach (var fd in td.Fields) {
-          if (fd.IsSpecialName && fd.Name == "value__") {
-            // If it's Int32, leave it off
-            if (fd.FieldType != fd.Module.TypeSystem.Int32) {
-              baseType = fd.FieldType;
-            }
-            break;
-          }
-        }
-      }
-      if (baseType is not null) {
-        // FIXME: Does this need a context?
-        sb.Append(" : ").Append(this.TypeName(baseType, td));
-      }
-      if (td.HasInterfaces) {
-        // Ensure these are emitted sorted
-        var interfaces = new SortedDictionary<string, string>();
-        foreach (var implementation in td.Interfaces) {
-          var it = implementation.InterfaceType;
-          // Don't emit IEquatable<this type> for records.
-          if (recordType && it.IsCoreLibraryType("System", "IEquatable`1") && it is GenericInstanceType git) {
-            if (git.HasGenericArguments && git.GenericArguments.Count == 1 && git.GenericArguments[0] == td) {
-              continue;
-            }
-          }
-          var type = this.TypeName(it, implementation, typeContext: td);
-          interfaces.Add(type, this.CustomAttributesInline(implementation) + type);
-        }
-        if (interfaces.Count > 0) {
-          sb.Append(baseType is null ? " : " : ", ").AppendJoin(", ", interfaces.Values);
-        }
-      }
-    }
-    {
-      var constraints = this.GenericParameterConstraints(td, indent + 2).ToList();
-      if (constraints.Count == 0) {
-        sb.Append(" {");
-      }
-      else {
-        constraints[constraints.Count - 1] += " {";
-      }
-      yield return sb.ToString();
-      sb.Clear();
-      foreach (var constraint in constraints) {
-        yield return constraint;
-      }
-    }
-    foreach (var line in this.Fields(td, indent + 2)) {
-      yield return line;
-    }
-    foreach (var line in this.Properties(td, indent + 2)) {
-      yield return line;
-    }
-    foreach (var line in this.Events(td, indent + 2)) {
-      yield return line;
-    }
-    foreach (var line in this.Methods(td, indent + 2)) {
-      yield return line;
-    }
-    foreach (var line in this.ExtensionBlocks(td, indent + 2)) {
-      yield return line;
-    }
-    foreach (var line in this.NestedTypes(td, indent + 2)) {
-      yield return line;
-    }
-    yield return null;
-    sb.Append(' ', indent).Append('}');
-    yield return sb.ToString();
-  }
-
   /// <inheritdoc />
   protected override string Null() => "null";
 
@@ -1688,10 +1533,201 @@ public class CSharpFormatter : CodeFormatter {
 
   /// <inheritdoc />
   protected override IEnumerable<string?> Type(TypeDefinition td, int indent) {
-    if (this.IsUnionType(td)) {
-      return this.UnionType(td, indent);
+    foreach (var line in this.CustomAttributes(td, indent)) {
+      yield return line;
     }
-    return this.NormalType(td, indent);
+    var sb = new StringBuilder();
+    // This IL flag is written as an attribute in C# code. Do the same.
+    if (td.IsSerializable) {
+      sb.Append(' ', indent).Append('[').Append(typeof(SerializableAttribute).FullName).Append(']');
+      yield return sb.ToString();
+      sb.Clear();
+    }
+    sb.Append(' ', indent);
+    if (td.IsPublic || td.IsNestedPublic) {
+      sb.Append("public ");
+    }
+    else if (td.IsNestedAssembly || td.IsNotPublic) {
+      sb.Append("internal ");
+    }
+    else if (td.IsNestedFamily) {
+      sb.Append("protected ");
+    }
+    else if (td.IsNestedFamilyAndAssembly) {
+      sb.Append("private protected ");
+    }
+    else if (td.IsNestedFamilyOrAssembly) {
+      sb.Append("protected ");
+      if (this.IncludeInternals) {
+        sb.Append("internal ");
+      }
+    }
+    else {
+      sb.Append("/* unexpected accessibility */ ");
+    }
+    if (td.IsDelegate(out var invoke)) {
+      sb.Append("delegate ");
+      this.MethodName(invoke, out var returnTypeName);
+      if (returnTypeName.Length > 0) {
+        sb.Append(returnTypeName).Append(' ');
+      }
+      sb.Append(this.TypeName(td)).Append(this.Parameters(invoke));
+      var constraints = this.GenericParameterConstraints(td, indent + 2).ToList();
+      if (constraints.Count == 0) {
+        sb.Append(';');
+      }
+      else {
+        constraints[constraints.Count - 1] += ';';
+      }
+      yield return sb.ToString();
+      sb.Clear();
+      foreach (var constraint in constraints) {
+        yield return constraint;
+      }
+      yield break;
+    }
+    if (td is { IsClass: true, IsAbstract: true, IsSealed: true }) {
+      sb.Append("static ");
+    }
+    else if (td is { IsAbstract: true, IsInterface: false }) {
+      sb.Append("abstract ");
+    }
+    else if (td is { IsSealed: true, IsValueType: false }) {
+      sb.Append("sealed ");
+    }
+    var unionType = CSharpFormatter.IsUnionType(td);
+    // The record check is relatively expensive, so avoid doing it if we've already detected a union.
+    var recordType = !unionType && CSharpFormatter.IsRecordType(td);
+    if (recordType) {
+      sb.Append("record");
+      if (td.IsValueType) {
+        sb.Append(" struct");
+      }
+    }
+    else if (unionType) {
+      sb.Append("union");
+    }
+    else if (td.IsEnum) {
+      sb.Append("enum");
+    }
+    else if (td.IsInterface) {
+      sb.Append("interface");
+    }
+    else if (td.IsValueType) {
+      if (td.IsReadOnly) {
+        sb.Append("readonly ");
+      }
+      if (td.IsByRefLike) {
+        sb.Append("ref ");
+      }
+      sb.Append("struct");
+    }
+    else if (td.IsClass) {
+      // TODO: Maybe detect delegates; but then what of explicitly written classes deriving from MultiCastDelegate?
+      sb.Append("class");
+    }
+    else { // What else can it be?
+      sb.Append($"/* type with unsupported classification: {td.Attributes} */");
+    }
+    // Note: The definition is NOT passed as context here (otherwise [NullableContext(2)] causes "public class Foo?").
+    sb.Append(' ').Append(this.TypeName(td));
+    if (unionType) {
+      var types = new List<string>();
+      foreach (var ctor in td.Methods.Where(md => md is { IsConstructor: true, Name: ".ctor", HasParameters: true })) {
+        if (ctor.Parameters.Count == 1) {
+          var param = ctor.Parameters[0];
+          types.Add(this.TypeName(param.ParameterType, param));
+        }
+      }
+      sb.Append('(').AppendJoin(", ", types).Append(')');
+    }
+    {
+      var baseType = td.BaseType;
+      if (baseType is not null) {
+        if (td.IsClass && baseType.IsCoreLibraryType("System", "Object")) {
+          baseType = null;
+        }
+        else if (td.IsEnum && baseType.IsCoreLibraryType("System", "Enum")) {
+          baseType = null;
+        }
+        else if (td.IsValueType && baseType.IsNamed("System", "ValueType")) {
+          baseType = null;
+        }
+      }
+      // For an enum, look for the special-named 'value__' field and use its type as the base type.
+      if (baseType is null && td is { IsEnum: true, HasFields: true }) {
+        foreach (var fd in td.Fields) {
+          if (fd.IsSpecialName && fd.Name == "value__") {
+            // If it's Int32, leave it off
+            if (fd.FieldType != fd.Module.TypeSystem.Int32) {
+              baseType = fd.FieldType;
+            }
+            break;
+          }
+        }
+      }
+      if (baseType is not null) {
+        // FIXME: Does this need a context?
+        sb.Append(" : ").Append(this.TypeName(baseType, td));
+      }
+      if (td.HasInterfaces) {
+        // Ensure these are emitted sorted
+        var interfaces = new SortedDictionary<string, string>();
+        foreach (var implementation in td.Interfaces) {
+          var it = implementation.InterfaceType;
+          // Don't emit IEquatable<this type> for records.
+          if (recordType && it.IsCoreLibraryType("System", "IEquatable`1") && it is GenericInstanceType git) {
+            if (git.HasGenericArguments && git.GenericArguments.Count == 1 && git.GenericArguments[0] == td) {
+              continue;
+            }
+          }
+          // Don't emit IUnion for unions.
+          if (unionType && it.IsNamed("System.Runtime.CompilerServices", "IUnion") && !it.HasGenericParameters) {
+            continue;
+          }
+          var type = this.TypeName(it, implementation, typeContext: td);
+          interfaces.Add(type, this.CustomAttributesInline(implementation) + type);
+        }
+        if (interfaces.Count > 0) {
+          sb.Append(baseType is null ? " : " : ", ").AppendJoin(", ", interfaces.Values);
+        }
+      }
+    }
+    {
+      var constraints = this.GenericParameterConstraints(td, indent + 2).ToList();
+      if (constraints.Count == 0) {
+        sb.Append(" {");
+      }
+      else {
+        constraints[constraints.Count - 1] += " {";
+      }
+      yield return sb.ToString();
+      sb.Clear();
+      foreach (var constraint in constraints) {
+        yield return constraint;
+      }
+    }
+    foreach (var line in this.Fields(td, indent + 2)) {
+      yield return line;
+    }
+    foreach (var line in this.Properties(td, indent + 2)) {
+      yield return line;
+    }
+    foreach (var line in this.Events(td, indent + 2)) {
+      yield return line;
+    }
+    foreach (var line in this.Methods(td, indent + 2)) {
+      yield return line;
+    }
+    foreach (var line in this.ExtensionBlocks(td, indent + 2)) {
+      yield return line;
+    }
+    foreach (var line in this.NestedTypes(td, indent + 2)) {
+      yield return line;
+    }
+    yield return null;
+    sb.Append(' ', indent).Append('}');
+    yield return sb.ToString();
   }
 
   /// <summary>Formats the type name for an exported type.</summary>
@@ -2037,17 +2073,6 @@ public class CSharpFormatter : CodeFormatter {
   protected override string TypeOf(TypeReference tr) {
     // FIXME: Does this need a context?
     return $"typeof({this.TypeName(tr)})";
-  }
-
-  /// <summary>Formats a C# union type.</summary>
-  /// <param name="td">The union type definition.</param>
-  /// <param name="indent">The number of spaces of indentation to use.</param>
-  /// <returns>The formatted union type.</returns>
-  protected IEnumerable<string?> UnionType(TypeDefinition td, int indent) {
-    yield return $"// TODO: Handle union type: {td}";
-    foreach (var line in this.NormalType(td, indent)) {
-      yield return line;
-    }
   }
 
 }

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -1554,8 +1554,8 @@ public class CSharpFormatter : CodeFormatter {
     var prefix = "";
     // ref X can only occur on outer types; can't have an array of `ref int` or a `Func<ref int>`, so handle that here
     if (tr is ByReferenceType brt) { // => ref T
-      // omit the "ref" for "out" parameters - it's covered by the "out"
-      if (context is not ParameterDefinition { IsOut: true }) {
+      // omit the "ref" for "in" or "out" parameters
+      if (context is ParameterDefinition { IsIn: false, IsOut: false }) {
         prefix = context.IsReadOnly ? "ref readonly " : "ref ";
       }
       tr = brt.ElementType;

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -656,8 +656,136 @@ public class CSharpFormatter : CodeFormatter {
   /// <param name="td">The type definition to check.</param>
   /// <returns><see langword="true"/> if it's a record type; <see langword="false"/> otherwise.</returns>
   protected bool IsRecordType(TypeDefinition td) {
-    // TODO
-    return false;
+    // Can't be an interface or an enum; can't be a static class.
+    if (td.IsInterface || td.IsEnum || td is { IsSealed: true, IsAbstract: true }) {
+      return false;
+    }
+    // Must have implemented interfaces and methods. Properties and fields are not technically required.
+    if (!td.HasInterfaces || !td.HasMethods) {
+      return false;
+    }
+    { // Must implement IEquatable<itself>.
+      var found = false;
+      foreach (var implemented in td.Interfaces.Select(ii => ii.InterfaceType).OfType<GenericInstanceType>()) {
+        if (!implemented.ElementType.IsCoreLibraryType("System", "IEquatable`1")) {
+          continue;
+        }
+        if (implemented.HasGenericArguments && implemented.GenericArguments.Count == 1 && implemented.GenericArguments[0] == td) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        return false;
+      }
+    }
+    var ts = td.Module.TypeSystem;
+    { // Check for compiler-generated == and != operators.
+      var eq = false;
+      var neq = false;
+      var ops = td.Methods.Where(md => md is {
+        IsCompilerGenerated: true,
+        IsSpecialName: true,
+        IsStatic: true,
+        Name: "op_Equality" or "op_Inequality",
+        HasParameters: true,
+        Parameters.Count: 2,
+      });
+      foreach (var op in ops) {
+        if (op.ReturnType != ts.Boolean) {
+          continue;
+        }
+        if (op.Parameters[0].ParameterType != td || op.Parameters[1].ParameterType != td) {
+          continue;
+        }
+        if (op.Name is "op_Equality") {
+          eq = true;
+        }
+        else {
+          neq = true;
+        }
+      }
+      if (!eq || !neq) {
+        return false;
+      }
+    }
+    // If not a struct, it must have a compiler-generated method called `<Clone>$` taking no parameters and returning this type.
+    if (!td.IsValueType) {
+      var clone = td.Methods.FirstOrDefault(md => md is {
+        HasParameters: false,
+        IsCompilerGenerated: true,
+        Name: "<Clone>$",
+      });
+      if (clone?.ReturnType != td) {
+        return false;
+      }
+    }
+    // Several methods should be present:
+    // - "<itself> <Clone>$()" (except for structs; should always be compiler-generated)
+    // - `int GetHashCode()`
+    // - `bool Equals(object)`
+    // - `bool Equals(<itself>)`
+    // - "bool PrintMembers(StringBuilder)"
+    // - `string ToString()`
+    {
+      var clone = td.IsValueType;
+      var hashCode = false;
+      var equals = false;
+      var equalsSelf = false;
+      var printMembers = false;
+      var toString = false;
+      foreach (var method in td.Methods) {
+        if (!clone && method is { HasParameters: false, IsCompilerGenerated: true, Name: "<Clone>$" }) {
+          if (method.ReturnType == td) {
+            clone = true;
+            continue;
+          }
+        }
+        if (!(equals && equalsSelf) && method is { HasParameters: true, Name: "Equals" }) {
+          if (method.ReturnType == ts.Boolean && method.Parameters.Count == 1) {
+            var pt = method.Parameters[0].ParameterType;
+            if (pt == td) {
+              equalsSelf = true;
+              continue;
+            }
+            if (pt == ts.Object) {
+              equals = true;
+              continue;
+            }
+          }
+        }
+        if (!hashCode && method is { HasParameters: false, Name: "GetHashCode" }) {
+          if (method.ReturnType == ts.Int32) {
+            hashCode = true;
+            continue;
+          }
+        }
+        if (!printMembers && method is { HasParameters: true, Name: "PrintMembers"}) {
+          if (method.ReturnType == ts.Boolean && method.Parameters.Count == 1) {
+            if (method.Parameters[0].ParameterType.IsCoreLibraryType("System.Text", "StringBuilder")) {
+              printMembers = true;
+              continue;
+            }
+          }
+        }
+        if (!toString && method is { HasParameters: false, Name: "ToString" }) {
+          if (method.ReturnType == ts.String) {
+            toString = true;
+            continue;
+          }
+        }
+      }
+      if (!clone || !hashCode || !equals || !equalsSelf || !printMembers || !toString) {
+        return false;
+      }
+    }
+    // Optional additional checks:
+    // - when it's a non-sealed record class, there should be a "copy constructor" (taking a single parameter of the record's type)
+    // - there can be a property named EqualityContract, of type System.Type, with only a getter
+    //   - it's not always present, so the correct logic to determine when it should be present needs to be determined first
+    // - there should be a "void Deconstruct()" method with all `out` parameters, but only when the record has properties (not
+    //   counting `EqualityContract`)
+    return true;
   }
 
   /// <summary>Determines whether a given type definition is for a C# union type.</summary>
@@ -1311,7 +1439,14 @@ public class CSharpFormatter : CodeFormatter {
     else if (td is { IsSealed: true, IsValueType: false }) {
       sb.Append("sealed ");
     }
-    if (td.IsEnum) {
+    var recordType = this.IsRecordType(td);
+    if (recordType) {
+      sb.Append("record");
+      if (td.IsValueType) {
+        sb.Append(" struct");
+      }
+    }
+    else if (td.IsEnum) {
       sb.Append("enum");
     }
     else if (td.IsInterface) {
@@ -1360,24 +1495,27 @@ public class CSharpFormatter : CodeFormatter {
           }
         }
       }
-      if (baseType is not null || td.HasInterfaces) {
-        sb.Append(" : ");
-      }
       if (baseType is not null) {
         // FIXME: Does this need a context?
-        sb.Append(this.TypeName(baseType, td));
-        if (td.HasInterfaces) {
-          sb.Append(", ");
-        }
+        sb.Append(" : ").Append(this.TypeName(baseType, td));
       }
       if (td.HasInterfaces) {
         // Ensure these are emitted sorted
         var interfaces = new SortedDictionary<string, string>();
         foreach (var implementation in td.Interfaces) {
-          var type = this.TypeName(implementation.InterfaceType, implementation, typeContext: td);
+          var it = implementation.InterfaceType;
+          // Don't emit IEquatable<this type> for records.
+          if (recordType && it.IsCoreLibraryType("System", "IEquatable`1") && it is GenericInstanceType git) {
+            if (git.HasGenericArguments && git.GenericArguments.Count == 1 && git.GenericArguments[0] == td) {
+              continue;
+            }
+          }
+          var type = this.TypeName(it, implementation, typeContext: td);
           interfaces.Add(type, this.CustomAttributesInline(implementation) + type);
         }
-        sb.AppendJoin(", ", interfaces.Values);
+        if (interfaces.Count > 0) {
+          sb.Append(baseType is null ? " : " : ", ").AppendJoin(", ", interfaces.Values);
+        }
       }
     }
     {
@@ -1548,20 +1686,8 @@ public class CSharpFormatter : CodeFormatter {
     return pd is { HasParameters: true, Name: "Item" } ? "this" : pd.Name;
   }
 
-  /// <summary>Formats a C# record type.</summary>
-  /// <param name="td">The record type definition.</param>
-  /// <param name="indent">The number of spaces of indentation to use.</param>
-  /// <returns>The formatted record type.</returns>
-  protected IEnumerable<string?> RecordType(TypeDefinition td, int indent) {
-    // TODO
-    yield break;
-  }
-
   /// <inheritdoc />
   protected override IEnumerable<string?> Type(TypeDefinition td, int indent) {
-    if (this.IsRecordType(td)) {
-      return this.RecordType(td, indent);
-    }
     if (this.IsUnionType(td)) {
       return this.UnionType(td, indent);
     }
@@ -1918,8 +2044,10 @@ public class CSharpFormatter : CodeFormatter {
   /// <param name="indent">The number of spaces of indentation to use.</param>
   /// <returns>The formatted union type.</returns>
   protected IEnumerable<string?> UnionType(TypeDefinition td, int indent) {
-    // TODO
-    yield break;
+    yield return $"// TODO: Handle union type: {td}";
+    foreach (var line in this.NormalType(td, indent)) {
+      yield return line;
+    }
   }
 
 }

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -9,6 +9,7 @@ using Mono.Cecil;
 namespace Zastai.Build.ApiReference;
 
 /// <summary>Utility methods for working with <c>Mono.Cecil</c> elements.</summary>
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
 internal static class CecilUtils {
 
   extension(AssemblyDefinition ad) {
@@ -122,7 +123,7 @@ internal static class CecilUtils {
                   arg = values[idx];
                 }
                 else {
-                  // There is a array of values but not for this index: should really be an error, but assume null-oblivious.
+                  // There is an array of values but not for this index: should really be an error, but assume null-oblivious.
                   return Nullability.Oblivious;
                 }
               }

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -337,8 +337,6 @@ internal static class CecilUtils {
 
   extension(TypeReference tr) {
 
-    public bool IsCompilerGenerated => ((ICustomAttributeProvider) tr.Resolve()).IsCompilerGenerated;
-
     public bool IsCoreLibraryType() => tr.Scope == tr.Module.TypeSystem.CoreLibrary;
 
     public bool IsCoreLibraryType(string? ns) => tr.IsCoreLibraryType() && tr.IsNamed(ns);

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -328,7 +328,7 @@ internal static class CecilUtils {
 
     public bool IsExtensionBlock => td is { IsSpecialName: true, IsMarkedAsExtension: true } && td.Name.StartsWith("<G>");
 
-    public bool IsInternalApi => td is not null && (td.IsNestedAssembly || td.IsNestedFamilyAndAssembly || td.IsNotPublic);
+    public bool IsInternalApi => td is not null && (td.IsNestedAssembly || td.IsNestedFamilyAndAssembly);
 
     public bool IsPublicApi
       => td is not null && (td.IsPublic || td.IsNestedPublic || td.IsNestedFamily || td.IsNestedFamilyOrAssembly);

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -295,6 +295,32 @@ internal static class CecilUtils {
       return null;
     }
 
+    public bool Implements(string ns, string name) {
+      if (td is null || !td.HasInterfaces) {
+        return false;
+      }
+      return td.Interfaces.Select(ii => ii.InterfaceType)
+               .Any(t => t.IsNamed(ns, name) && !t.HasGenericParameters && t is not GenericInstanceType);
+    }
+
+    public bool Implements(string ns, string name, params IReadOnlyList<TypeReference> typeArguments) {
+      if (td is null || !td.HasInterfaces) {
+        return false;
+      }
+      foreach (var it in td.Interfaces.Select(ii => ii.InterfaceType).Where(it => it.IsNamed(ns, name))) {
+        if (it.HasGenericParameters || it is not GenericInstanceType git) {
+          continue;
+        }
+        if (!git.HasGenericArguments || git.GenericArguments.Count != typeArguments.Count) {
+          continue;
+        }
+        if (git.GenericArguments.SequenceEqual(typeArguments)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     public bool IsByRefLike => td.HasAttribute("System.Runtime.CompilerServices", "IsByRefLikeAttribute");
 
     public bool IsDelegate([NotNullWhen(true)] out MethodDefinition? invoke) {
@@ -329,6 +355,8 @@ internal static class CecilUtils {
     public bool IsExtensionBlock => td is { IsSpecialName: true, IsMarkedAsExtension: true } && td.Name.StartsWith("<G>");
 
     public bool IsInternalApi => td is not null && (td.IsNestedAssembly || td.IsNestedFamilyAndAssembly);
+
+    public bool IsMarkedAsUnion => td.HasAttribute("System.Runtime.CompilerServices", "UnionAttribute");
 
     public bool IsPublicApi
       => td is not null && (td.IsPublic || td.IsNestedPublic || td.IsNestedFamily || td.IsNestedFamilyOrAssembly);

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -478,15 +478,21 @@ public abstract partial class CodeFormatter {
     this._runtimeFeatures = null;
   }
 
+  private const string FormatUsingAssemblyDefinitionOnly =
+    $"Use the version taking an {nameof(AssemblyDefinition)}; otherwise, that gets disposed before all processing is complete, " +
+    $"which can cause problems.";
+
   /// <summary>Formats the public API for an assembly.</summary>
   /// <param name="assembly">A stream containing the assembly to process.</param>
   /// <returns>The formatted public API for the assembly, line by line.</returns>
+  [Obsolete(CodeFormatter.FormatUsingAssemblyDefinitionOnly)]
   public IEnumerable<string?> FormatPublicApi(Stream assembly) => this.FormatPublicApi(assembly, new ReaderParameters());
 
   /// <summary>Formats the public API for an assembly.</summary>
   /// <param name="assembly">A stream containing the assembly to process.</param>
   /// <param name="parameters">The parameters to apply when reading the assembly.</param>
   /// <returns>The formatted public API for the assembly, line by line.</returns>
+  [Obsolete(CodeFormatter.FormatUsingAssemblyDefinitionOnly)]
   public IEnumerable<string?> FormatPublicApi(Stream assembly, ReaderParameters parameters) {
     using var ad = AssemblyDefinition.ReadAssembly(assembly, parameters);
     return this.FormatPublicApi(ad);
@@ -495,12 +501,14 @@ public abstract partial class CodeFormatter {
   /// <summary>Formats the public API for an assembly.</summary>
   /// <param name="assemblyPath">The path to the assembly to process.</param>
   /// <returns>The formatted public API for the assembly, line by line.</returns>
+  [Obsolete(CodeFormatter.FormatUsingAssemblyDefinitionOnly)]
   public IEnumerable<string?> FormatPublicApi(string assemblyPath) => this.FormatPublicApi(assemblyPath, new ReaderParameters());
 
   /// <summary>Formats the public API for an assembly.</summary>
   /// <param name="assemblyPath">The path to the assembly to process.</param>
   /// <param name="parameters">The parameters to apply when reading the assembly.</param>
   /// <returns>The formatted public API for the assembly, line by line.</returns>
+  [Obsolete(CodeFormatter.FormatUsingAssemblyDefinitionOnly)]
   public IEnumerable<string?> FormatPublicApi(string assemblyPath, ReaderParameters parameters) {
     using var ad = AssemblyDefinition.ReadAssembly(assemblyPath, parameters);
     return this.FormatPublicApi(ad);

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -209,7 +209,7 @@ public abstract partial class CodeFormatter {
     }
     var events = new SortedDictionary<string, EventDefinition>();
     foreach (var ed in td.Events) {
-      if (!this.ShouldInclude(ed)) {
+      if (!this.ShouldInclude(ed) || ed.IsCompilerGenerated) {
         continue;
       }
       // Assumption: no overloads for these
@@ -319,7 +319,7 @@ public abstract partial class CodeFormatter {
     }
     var fields = new SortedDictionary<string, FieldDefinition>();
     foreach (var field in td.Fields) {
-      if (!this.ShouldInclude(field)) {
+      if (!this.ShouldInclude(field) || field.IsCompilerGenerated) {
         continue;
       }
       if (fields.TryGetValue(field.Name, out var previousField)) {
@@ -688,6 +688,9 @@ public abstract partial class CodeFormatter {
       if (!this.ShouldInclude(method) || method.IsAddOn || method.IsGetter || method.IsRemoveOn || method.IsSetter) {
         continue;
       }
+      if (method.IsCompilerGenerated) {
+        continue;
+      }
       if (methods.Add(method)) {
         continue;
       }
@@ -771,10 +774,7 @@ public abstract partial class CodeFormatter {
     }
     var nestedTypes = new SortedDictionary<string, TypeDefinition>();
     foreach (var type in td.NestedTypes) {
-      if (!this.ShouldInclude(type)) {
-        continue;
-      }
-      if (type.IsExtensionBlock) {
+      if (!this.ShouldInclude(type) || type.IsCompilerGenerated || type.IsExtensionBlock) {
         continue;
       }
       if (nestedTypes.TryGetValue(type.Name, out var previousType)) {
@@ -815,6 +815,9 @@ public abstract partial class CodeFormatter {
     var properties = new SortedSet<PropertyDefinition>(this);
     foreach (var property in td.Properties) {
       if (!this.ShouldInclude(property.GetMethod) && !this.ShouldInclude(property.SetMethod)) {
+        continue;
+      }
+      if (property.IsCompilerGenerated) {
         continue;
       }
       if (property.HasParameters) {
@@ -923,7 +926,7 @@ public abstract partial class CodeFormatter {
     foreach (var md in ad.Modules) {
       if (md.HasTypes) {
         foreach (var td in md.Types) {
-          if (!this.ShouldInclude(td)) {
+          if (!this.ShouldInclude(td) || td.IsCompilerGenerated) {
             continue;
           }
           if (!namespacedTypes.TryGetValue(td.Namespace, out var types)) {

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -10,6 +11,7 @@ using Mono.Cecil;
 namespace Zastai.Build.ApiReference;
 
 /// <summary>A class that will extract and format the public API for an assembly.</summary>
+[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
 public abstract partial class CodeFormatter {
 
   private readonly HashSet<string> _attributesToExclude = [];
@@ -877,11 +879,11 @@ public abstract partial class CodeFormatter {
     // For everything else, use the configured inclusion/exclusion processing
     var name = ca.AttributeType.FullName;
     if (this._attributesToInclude.Count > 0) {
-      if (!this._attributesToInclude.Any(pattern => name.Matches(pattern))) {
+      if (!this._attributesToInclude.Any(name.Matches)) {
         return false;
       }
     }
-    return this._attributesToExclude.All(pattern => !name.Matches(pattern));
+    return !this._attributesToExclude.Any(name.Matches);
   }
 
   private bool ShouldInclude(EventDefinition ed) => ed.IsPublicApi || (this.IncludeInternals && ed.IsInternalApi);

--- a/Zastai.Build.ApiReference.Library/Constants.cs
+++ b/Zastai.Build.ApiReference.Library/Constants.cs
@@ -12,8 +12,6 @@ public static partial class Constants {
 
   }
 
-#if NET8_0_OR_GREATER
-
   /// <summary>
   /// A regular expression representing a valid F# custom operator method name (not including the <c>op_</c> prefix or possible
   /// <c>$W</c> suffix).<br/>
@@ -113,117 +111,21 @@ public static partial class Constants {
   ///   </item>
   /// </list>
   /// </summary>
+
+#if NET8_0_OR_GREATER
+
   [GeneratedRegex(PatternText.FSharpCustomOperator)]
   public static partial Regex FSharpCustomOperatorPattern();
 
 #else
+
+  public static Regex FSharpCustomOperatorPattern() => RegexInstances.FSharpCustomOperator;
 
   private static class RegexInstances {
 
     public static readonly Regex FSharpCustomOperator = new(PatternText.FSharpCustomOperator);
 
   }
-
-  /// <summary>
-  /// A regular expression representing a valid F# custom operator method name (not including the <c>op_</c> prefix or possible
-  /// <c>$W</c> suffix).<br/>
-  /// This consists of one or more words representing the symbols F# allows in custom operators:
-  /// <list type="table">
-  ///   <listheader>
-  ///     <term>Symbol</term>
-  ///     <description>Word</description>
-  ///   </listheader>
-  ///   <item>
-  ///     <term>&amp;</term>
-  ///     <description>Amp</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>@</term>
-  ///     <description>At</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>!</term>
-  ///     <description>Bang</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>|</term>
-  ///     <description>Bar</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>,</term>
-  ///     <description>Comma</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>/</term>
-  ///     <description>Divide</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>$</term>
-  ///     <description>Dollar</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>.</term>
-  ///     <description>Dot</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>=</term>
-  ///     <description>Equals</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>&gt;</term>
-  ///     <description>Greater</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>^</term>
-  ///     <description>Hat</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>[</term>
-  ///     <description>LBrack</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>(</term>
-  ///     <description>LParen</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>&lt;</term>
-  ///     <description>Less</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>-</term>
-  ///     <description>Minus</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>*</term>
-  ///     <description>Multiply</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>%</term>
-  ///     <description>Percent</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>+</term>
-  ///     <description>Plus</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>?</term>
-  ///     <description>Qmark</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>]</term>
-  ///     <description>RBrack</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>)</term>
-  ///     <description>RParen</description>
-  ///   </item>
-  ///   <item>
-  ///     <term>~</term>
-  ///     <description>Twiddle</description>
-  ///   </item>
-  /// </list>
-  /// </summary>
-  public static Regex FSharpCustomOperatorPattern() => RegexInstances.FSharpCustomOperator;
 
 #endif
 

--- a/Zastai.Build.ApiReference.Library/Utils.cs
+++ b/Zastai.Build.ApiReference.Library/Utils.cs
@@ -52,10 +52,8 @@ internal static class Utils {
       ++patternPosition;
       ++textPosition;
     }
-
   }
 
   public static ulong ToULong(this object value) => value is ulong u64 ? u64 : (ulong) Convert.ToInt64(value);
-
 
 }

--- a/Zastai.Build.ApiReference.Tool/Program.cs
+++ b/Zastai.Build.ApiReference.Tool/Program.cs
@@ -155,8 +155,9 @@ public static class Program {
     formatter.IncludeExtensionBlocks = includeExtensionBlocks;
     formatter.IncludeInternals = includeInternals;
     try {
+      using var ad = AssemblyDefinition.ReadAssembly(assembly, Program.CreateReaderParameters(assembly, dependencyPath));
       using var reference = referenceSource == "-" ? Console.Out : new StreamWriter(File.Create(referenceSource), Encoding.UTF8);
-      foreach (var line in formatter.FormatPublicApi(assembly, Program.CreateReaderParameters(assembly, dependencyPath))) {
+      foreach (var line in formatter.FormatPublicApi(ad)) {
         if (line is null) {
           reference.WriteLine();
         }

--- a/Zastai.Build.ApiReference/GenerateApiReference.cs
+++ b/Zastai.Build.ApiReference/GenerateApiReference.cs
@@ -153,8 +153,9 @@ public sealed class GenerateApiReference : ITask {
     formatter.IncludeExtensionBlocks = this.IncludeExtensionBlocks;
     formatter.IncludeInternals = includeInternals;
     try {
+      using var ad = AssemblyDefinition.ReadAssembly(assembly, this.CreateReaderParameters(assembly, libraryPath));
       using var reference = new StreamWriter(File.Create(referenceSource), Encoding.UTF8);
-      foreach (var line in formatter.FormatPublicApi(assembly, this.CreateReaderParameters(assembly, libraryPath))) {
+      foreach (var line in formatter.FormatPublicApi(ad)) {
         reference.WriteLine(line);
       }
     }


### PR DESCRIPTION
This will now detect `record` and `union` types, rendering them closer to how they are written.

Fixes #102.
Fixes #103.