### PR TITLE
Improve property formatting

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>$(RepositoryUrl)/blob/main/README.md</PackageProjectUrl>
     <PackageReadMeFile>README.md</PackageReadMeFile>
-    <Version>3.1.2-pre</Version>
+    <Version>4.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CSharpFormatter.cs
@@ -117,6 +117,9 @@ public class CSharpFormatter : CodeFormatter {
       var isOverride = md is { IsReuseSlot: true, IsStatic: false } or { IsNewSlot: true, HasCovariantReturn: true };
       sb.Append(isOverride ? "override " : "virtual ");
     }
+    if (md.IsReadOnly) {
+      sb.Append("readonly ");
+    }
     return sb.ToString();
   }
 
@@ -844,7 +847,7 @@ public class CSharpFormatter : CodeFormatter {
         return "'\\a'";
       case '\b':
         return "'\\b'";
-      case '\u001f': // \e in C#13
+      case '\e':
         return "'\\e'";
       case '\f':
         return "'\\f'";
@@ -943,7 +946,7 @@ public class CSharpFormatter : CodeFormatter {
         case '\b':
           sb.Append("\\b");
           break;
-        case '\u001f': // \e in C#13
+        case '\e':
           sb.Append("\\e");
           break;
         case '\f':
@@ -1040,9 +1043,6 @@ public class CSharpFormatter : CodeFormatter {
       }
     }
     sb.Append(' ', indent).Append(this.Attributes(md));
-    if (md.IsReadOnly) {
-      sb.Append("readonly ");
-    }
     var methodName = this.MethodName(md, out var returnTypeName);
     if (returnTypeName.Length > 0) {
       sb.Append(returnTypeName).Append(' ');
@@ -1463,13 +1463,24 @@ public class CSharpFormatter : CodeFormatter {
   }
 
   /// <inheritdoc />
-  protected override IEnumerable<string?> Property(PropertyDefinition pd, int indent) {
+  protected override IEnumerable<string?> Property(PropertyDefinition pd, int indent, bool includeGetter, bool includeSetter) {
     foreach (var line in this.CustomAttributes(pd, indent)) {
       yield return line;
     }
+    var attributesOnAccessors = true;
+    var getter = includeGetter ? pd.GetMethod : null;
+    var setter = includeSetter ? pd.SetMethod : null;
     {
       var sb = new StringBuilder();
       sb.Append(' ', indent);
+      {
+        var getAttributes = getter is null ? null : this.Attributes(getter);
+        var setAttributes = setter is null ? null : this.Attributes(setter);
+        if (getAttributes is null || setAttributes is null || getAttributes == setAttributes) {
+          sb.Append(getAttributes ?? setAttributes);
+          attributesOnAccessors = false;
+        }
+      }
       if (pd.IsRequired) {
         sb.Append("required ");
       }
@@ -1478,15 +1489,19 @@ public class CSharpFormatter : CodeFormatter {
       sb.Append(this.Parameters(pd)).Append(" {");
       yield return sb.ToString();
     }
-    foreach (var line in this.PropertyAccessor(pd.GetMethod.IfPublicApi(), indent + 2)) {
-      yield return line;
+    if (getter is not null) {
+      foreach (var line in this.PropertyAccessor(getter, indent + 2, attributesOnAccessors)) {
+        yield return line;
+      }
     }
-    foreach (var line in this.PropertyAccessor(pd.SetMethod.IfPublicApi(), indent + 2)) {
-      yield return line;
+    if (setter is not null) {
+      foreach (var line in this.PropertyAccessor(setter, indent + 2, attributesOnAccessors)) {
+        yield return line;
+      }
     }
     if (pd.HasOtherMethods) {
       var sb = new StringBuilder();
-      sb.Append(' ', indent + 2).Append("// unsupported: \"other methods\"");
+      sb.Append(' ', indent + 2).Append($"// unsupported: \"other methods\" ({pd.OtherMethods.Count})");
       yield return sb.ToString();
     }
     {
@@ -1496,7 +1511,7 @@ public class CSharpFormatter : CodeFormatter {
     }
   }
 
-  private IEnumerable<string?> PropertyAccessor(MethodDefinition? method, int indent) {
+  private IEnumerable<string?> PropertyAccessor(MethodDefinition? method, int indent, bool includeAttributes) {
     if (method is null) {
       yield break;
     }
@@ -1504,9 +1519,9 @@ public class CSharpFormatter : CodeFormatter {
       yield return line;
     }
     var sb = new StringBuilder();
-    sb.Append(' ', indent).Append(this.Attributes(method));
-    if (method.IsReadOnly) {
-      sb.Append("readonly ");
+    sb.Append(' ', indent);
+    if (includeAttributes) {
+      sb.Append(this.Attributes(method));
     }
     if (method.IsGetter) {
       sb.Append("get");

--- a/Zastai.Build.ApiReference.Library/CecilUtils.cs
+++ b/Zastai.Build.ApiReference.Library/CecilUtils.cs
@@ -265,8 +265,6 @@ internal static class CecilUtils {
 
     public bool HasCovariantReturn => md.HasAttribute("System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute");
 
-    public MethodDefinition? IfPublicApi() => md.IsPublicApi ? md : null;
-
     public bool IsInternalApi => md is not null && (md.IsAssembly || md.IsFamilyAndAssembly);
 
     public bool IsPublicApi => md is not null && (md.IsPublic || md.IsFamily || md.IsFamilyOrAssembly);

--- a/Zastai.Build.ApiReference.Library/CodeFormatter.cs
+++ b/Zastai.Build.ApiReference.Library/CodeFormatter.cs
@@ -813,8 +813,12 @@ public abstract partial class CodeFormatter {
     }
     var parametrizedProperties = new SortedDictionary<string, SortedSet<PropertyDefinition>>();
     var properties = new SortedSet<PropertyDefinition>(this);
+    var propertiesWithGetter = new HashSet<PropertyDefinition>();
+    var propertiesWithSetter = new HashSet<PropertyDefinition>();
     foreach (var property in td.Properties) {
-      if (!this.ShouldInclude(property.GetMethod) && !this.ShouldInclude(property.SetMethod)) {
+      var includeGetter = this.ShouldInclude(property.GetMethod);
+      var includeSetter = this.ShouldInclude(property.SetMethod);
+      if (!includeGetter && !includeSetter) {
         continue;
       }
       if (property.IsCompilerGenerated) {
@@ -837,18 +841,24 @@ public abstract partial class CodeFormatter {
         }
         properties.Add(property);
       }
+      if (includeGetter) {
+        propertiesWithGetter.Add(property);
+      }
+      if (includeSetter) {
+        propertiesWithSetter.Add(property);
+      }
     }
     foreach (var overloads in parametrizedProperties.Values) {
       foreach (var pd in overloads) {
         yield return null;
-        foreach (var line in this.Property(pd, indent)) {
+        foreach (var line in this.Property(pd, indent, propertiesWithGetter.Contains(pd), propertiesWithSetter.Contains(pd))) {
           yield return line;
         }
       }
     }
     foreach (var pd in properties) {
       yield return null;
-      foreach (var line in this.Property(pd, indent)) {
+      foreach (var line in this.Property(pd, indent, propertiesWithGetter.Contains(pd), propertiesWithSetter.Contains(pd))) {
         yield return line;
       }
     }
@@ -857,8 +867,10 @@ public abstract partial class CodeFormatter {
   /// <summary>Formats a property.</summary>
   /// <param name="pd">The property to format.</param>
   /// <param name="indent">The number of spaces of indentation to use.</param>
+  /// <param name="includeGetter">Indicates whether the property's getter should be included.</param>
+  /// <param name="includeSetter">Indicates whether the property's setter should be included.</param>
   /// <returns>The formatted property (including any attributes attached to it).</returns>
-  protected abstract IEnumerable<string?> Property(PropertyDefinition pd, int indent);
+  protected abstract IEnumerable<string?> Property(PropertyDefinition pd, int indent, bool includeGetter, bool includeSetter);
 
   /// <summary>Formats the name of a property.</summary>
   /// <param name="pd">The property.</param>


### PR DESCRIPTION
When outputting properties, the method attributes are now output before the property when they are the same for all applicable accessors. This required an API break in the library, so the version has been bumped to 4.0.0.

This also fixes output of property accessors when non-public API is requested; previously, the property would get selected for output, but the accessor would be left off.